### PR TITLE
feat: Implement low-level CoW page operations, orphan management

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,2 @@
+mod page;
+mod snapshot;

--- a/src/page.rs
+++ b/src/page.rs
@@ -1,0 +1,6 @@
+mod page;
+mod manager;
+mod orphan;
+
+pub use page::{Page, PageMut, PAGE_SIZE, PAGE_DATA_SIZE};
+pub use manager::{PageError, PageId, PageManager};

--- a/src/page/manager.rs
+++ b/src/page/manager.rs
@@ -1,15 +1,18 @@
 use std::fmt::Debug;
+use crate::page::{Page, PageMut};
+use crate::snapshot::SnapshotId;
+
+mod mmap;
+mod orphan_aware;
 
 /// currently we use 4 bytes for page ids, which implies a maximum of 16TB of data.
 pub type PageId = u32;
-
-/// TODO: potentially use a a more sophisticated snapshotting mechanism that requires a Snapshot struct to carry more context.
-pub type SnapshotId = u64;
 
 /// Represents various errors that might arise from page operations.
 #[derive(Debug)]
 pub enum PageError {
     PageNotFound(PageId),
+    OutOfBounds(PageId),
     IO(std::io::Error),
     // TODO: add more errors here for other cases.
 }
@@ -17,34 +20,40 @@ pub enum PageError {
 /// Core trait that manages pages in trie db.
 pub trait PageManager: Debug {
     /// Retrieves a page from the given snapshot.
-    fn get(&self, snapshot_id: SnapshotId, page_id: PageId) -> Result<Page, PageError>;
+    fn get<'p>(&'p self, snapshot_id: SnapshotId, page_id: PageId) -> Result<Page<'p>, PageError>;
+
+    /// Retrieves a mutable page from the given snapshot.
+    fn get_mut<'p>(&'p mut self, snapshot_id: SnapshotId, page_id: PageId) -> Result<PageMut<'p>, PageError>;
+
+    /// Retrieves a mutable clone of a page from the given snapshot.
+    fn get_mut_clone<'p>(&'p mut self, snapshot_id: SnapshotId, page_id: PageId) -> Result<PageMut<'p>, PageError>;
 
     /// Allocates a new page in the given snapshot.
-    fn allocate(&mut self, snapshot_id: SnapshotId) -> Result<PageId, PageError>;
+    fn allocate<'p>(&'p mut self, snapshot_id: SnapshotId) -> Result<PageMut<'p>, PageError>;
 
-    /// Merges two pages into a new page.
-    fn merge(
-        &mut self,
-        snapshot_id: SnapshotId,
-        page_a: PageId,
-        page_b: PageId,
-        page_out: PageId,
-    ) -> Result<(), PageError>;
+    // /// Merges two pages into a new page.
+    // fn merge(
+    //     &mut self,
+    //     snapshot_id: SnapshotId,
+    //     page_a: PageId,
+    //     page_b: PageId,
+    //     page_out: PageId,
+    // ) -> Result<(), PageError>;
 
-    /// Splits a page into two new pages.
-    fn split(
-        &mut self,
-        snapshot_id: SnapshotId,
-        page_id: PageId,
-    ) -> Result<(PageId, PageId), PageError>;
+    // /// Splits a page into two new pages.
+    // fn split(
+    //     &mut self,
+    //     snapshot_id: SnapshotId,
+    //     page_id: PageId,
+    // ) -> Result<(PageId, PageId), PageError>;
 
-    /// Writes data to a page.
-    fn write(
-        &mut self,
-        snapshot_id: SnapshotId,
-        page_id: PageId,
-        data: &[u8],
-    ) -> Result<(), PageError>;
+    // /// Writes data to a page.
+    // fn write(
+    //     &mut self,
+    //     snapshot_id: SnapshotId,
+    //     page_id: PageId,
+    //     data: &[u8],
+    // ) -> Result<(), PageError>;
 
     /// Commits pages associated with a snapshot to durable storage.
     fn commit(&mut self, snapshot_id: SnapshotId) -> Result<(), PageError>;

--- a/src/page/manager/mmap.rs
+++ b/src/page/manager/mmap.rs
@@ -1,0 +1,150 @@
+use memmap2::MmapMut;
+use crate::page::{Page, PageError, PageId, PageManager, PageMut, PAGE_DATA_SIZE, PAGE_SIZE};
+use crate::snapshot::SnapshotId;
+
+// Manages pages in a memory mapped file.
+#[derive(Debug)]
+pub struct MmapPageManager {
+    mmap: MmapMut,
+    next_page_id: PageId,
+}
+
+impl MmapPageManager {
+    // Creates a new MmapPageManager with the given memory mapped file.
+    pub fn new(mmap: MmapMut, next_page_id: PageId) -> Self {
+        if next_page_id > (mmap.len() / PAGE_SIZE as usize) as u32 {
+            panic!("next_page_id is greater than the number of pages in the memory mapped file");
+        }
+        Self { mmap, next_page_id }
+    }
+
+    // Returns a mutable reference to the data of the page with the given id.
+    fn page_data<'p>(&'p self, page_id: PageId) -> Result<&'p mut [u8; PAGE_SIZE], PageError> {
+        if page_id >= self.next_page_id {
+            return Err(PageError::PageNotFound(page_id));
+        }
+        let start = page_id as usize * PAGE_SIZE;
+        let page_data = unsafe {
+            &mut *(self.mmap.as_ptr().add(start) as *mut [u8; PAGE_SIZE])
+        };
+        Ok(page_data)
+    }
+
+    // Allocates a new page in the memory mapped file.
+    fn allocate_page_data<'p>(&'p mut self) -> Result<(PageId, &'p mut [u8; PAGE_SIZE]), PageError> {
+        let page_id = self.next_page_id;
+
+        if (page_id + 1) as usize * PAGE_SIZE > self.mmap.len() {
+            return Err(PageError::OutOfBounds(page_id));
+        }
+
+        self.next_page_id += 1;
+        let page_data = self.page_data(page_id)?;
+        page_data.fill(0);
+        Ok((page_id, page_data))
+    }
+}
+
+impl PageManager for MmapPageManager {
+    // Retrieves a page from the memory mapped file.
+    fn get<'p>(&'p self, snapshot_id: SnapshotId, page_id: PageId) -> Result<Page<'p>, PageError> {
+        let page_data = self.page_data(page_id)?;
+        Ok(Page::new(page_id, page_data))
+    }
+
+    // Retrieves a mutable page from the memory mapped file.
+    fn get_mut<'p>(&'p mut self, snapshot_id: SnapshotId, page_id: PageId) -> Result<PageMut<'p>, PageError> {
+        let page_data = self.page_data(page_id)?;
+        Ok(PageMut::new(page_id, snapshot_id, page_data))
+    }
+
+    // Retrieves a mutable clone of a page from the memory mapped file.
+    fn get_mut_clone<'p>(&'p mut self, snapshot_id: SnapshotId, page_id: PageId) -> Result<PageMut<'p>, PageError> {
+        let mut buf = [0; PAGE_DATA_SIZE];
+        let old_page_data = self.get(snapshot_id, page_id)?.contents();
+        buf[..].copy_from_slice(old_page_data);
+        let (new_page_id, new_page_data) = self.allocate_page_data()?;
+        new_page_data.copy_from_slice(&buf);
+        Ok(PageMut::new(new_page_id, snapshot_id, new_page_data))
+    }
+
+    // Allocates a new page in the memory mapped file.
+    fn allocate<'p>(&'p mut self, snapshot_id: SnapshotId) -> Result<PageMut<'p>, PageError> {
+        let (page_id, page_data) = self.allocate_page_data()?;
+        Ok(PageMut::new(page_id, snapshot_id, page_data))
+    }
+
+    // Commits the memory mapped file to disk.
+    fn commit(&mut self, snapshot_id: SnapshotId) -> Result<(), PageError> {
+        self.mmap.flush().map_err(PageError::IO)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::page::page::PAGE_DATA_SIZE;
+
+    #[test]
+    fn test_allocate_get() {
+        let mmap = MmapMut::map_anon(10*PAGE_SIZE).unwrap();
+        let mut manager = MmapPageManager::new(mmap, 0);
+
+        for i in 0..10 {
+            let err = manager.get(42, i).unwrap_err();
+            assert!(matches!(err, PageError::PageNotFound(i)));
+
+            let mut page = manager.allocate(42).unwrap();
+            assert_eq!(page.id, i);
+            assert_eq!(page.contents(), &mut [0; PAGE_DATA_SIZE]);
+            assert_eq!(page.snapshot_id(), 42);
+
+            let page = manager.get(42, i).unwrap();
+            assert_eq!(page.id, i);
+            assert_eq!(page.contents(), &mut [0; PAGE_DATA_SIZE]);
+            assert_eq!(page.snapshot_id(), 42);
+        }
+
+        let err = manager.allocate(42).unwrap_err();
+        assert!(matches!(err, PageError::OutOfBounds(10)));
+    }
+
+    #[test]
+    fn test_allocate_get_mut_clone() {
+        let mmap = MmapMut::map_anon(10*PAGE_SIZE).unwrap();
+        let mut manager = MmapPageManager::new(mmap, 0);
+
+        let mut page = manager.allocate(42).unwrap();
+        assert_eq!(page.id, 0);
+        assert_eq!(page.contents(), &mut [0; PAGE_DATA_SIZE]);
+        assert_eq!(page.snapshot_id(), 42);
+
+        page.contents_mut()[0] = 1;
+
+        manager.commit(42).unwrap();
+
+        let old_page = manager.get(42, 0).unwrap();
+        assert_eq!(old_page.id, 0);
+        assert_eq!(old_page.contents()[0], 1);
+        assert_eq!(old_page.snapshot_id(), 42);
+
+        let mut new_page = manager.get_mut_clone(42, 0).unwrap();
+        assert_eq!(new_page.id, 1);
+        assert_eq!(new_page.contents()[0], 1);
+        assert_eq!(new_page.snapshot_id(), 42);
+
+        new_page.contents_mut()[0] = 2;
+        manager.commit(42).unwrap();
+
+        let old_page = manager.get(42, 0).unwrap();
+        assert_eq!(old_page.id, 0);
+        assert_eq!(old_page.contents()[0], 1);
+        assert_eq!(old_page.snapshot_id(), 42);
+
+        let new_page = manager.get(42, 1).unwrap();
+        assert_eq!(new_page.id, 1);
+        assert_eq!(new_page.contents()[0], 2);
+        assert_eq!(new_page.snapshot_id(), 42);
+
+    }
+}

--- a/src/page/manager/orphan_aware.rs
+++ b/src/page/manager/orphan_aware.rs
@@ -1,0 +1,111 @@
+use crate::page::{Page, PageError, PageId, PageManager, PageMut, PAGE_DATA_SIZE};
+use crate::snapshot::SnapshotId;
+use crate::page::orphan::OrphanPageManager;
+
+// A page manager that is aware of orphaned pages and can allocate new pages from them.
+#[derive(Debug)]
+pub struct OrphanAwarePageManager<M: PageManager> {
+    manager: M,
+    orphan_manager: OrphanPageManager,
+}
+
+impl<M: PageManager> OrphanAwarePageManager<M> {
+    // Creates a new OrphanAwarePageManager with the given page manager and orphan manager.
+    pub fn new(manager: M, orphan_manager: OrphanPageManager) -> Self {
+        Self { manager, orphan_manager }
+    }
+}
+
+impl<M: PageManager> PageManager for OrphanAwarePageManager<M> {
+    // Retrieves a page from the underlying page manager.
+    fn get<'p>(&'p self, snapshot_id: SnapshotId, page_id: PageId) -> Result<Page<'p>, PageError> {
+        self.manager.get(snapshot_id, page_id)
+    }
+
+    // Retrieves a mutable page from the underlying page manager.
+    fn get_mut<'p>(&'p mut self, snapshot_id: SnapshotId, page_id: PageId) -> Result<PageMut<'p>, PageError> {
+        self.manager.get_mut(snapshot_id, page_id)
+    }
+
+    // Retrieves a mutable clone of a page from the underlying page manager.
+    // The original page is marked as orphaned and a new page is allocated, potentially from an orphaned page.
+    fn get_mut_clone<'p>(&'p mut self, snapshot_id: SnapshotId, page_id: PageId) -> Result<PageMut<'p>, PageError> {
+        let mut buf = [0; PAGE_DATA_SIZE];
+        let original_page_data = self.get(snapshot_id, page_id)?.contents();
+        buf[..].copy_from_slice(original_page_data);
+        self.orphan_manager.add_orphaned_page_id(snapshot_id, page_id);
+        let mut new_page = self.allocate(snapshot_id)?;
+        new_page.contents_mut().copy_from_slice(&buf);
+        Ok(new_page)
+    }
+
+    // Allocates a new page from the underlying page manager.
+    // If there is an orphaned page available as of the given snapshot id,
+    // it is used to allocate a new page instead.
+    fn allocate<'p>(&'p mut self, snapshot_id: SnapshotId) -> Result<PageMut<'p>, PageError> {
+        let orphaned_page_id = self.orphan_manager.get_orphaned_page_id(snapshot_id-1);
+        if let Some(orphaned_page_id) = orphaned_page_id {
+            let mut page = self.get_mut(snapshot_id, orphaned_page_id)?;
+            page.contents_mut().fill(0);
+            Ok(page)
+        } else {
+            self.manager.allocate(snapshot_id)
+        }
+    }
+
+    // Commits the underlying page manager to disk.
+    fn commit(&mut self, snapshot_id: SnapshotId) -> Result<(), PageError> {
+        self.manager.commit(snapshot_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use memmap2::MmapMut;
+    use crate::page::manager::mmap::MmapPageManager;
+    use crate::page::PAGE_SIZE;
+
+    #[test]
+    fn test_allocate_get_mut_clone() {
+        let mmap = MmapMut::map_anon(10*PAGE_SIZE).unwrap();
+        let manager = MmapPageManager::new(mmap, 0);
+        let orphan_manager = OrphanPageManager::new();
+        let mut orphan_aware_manager = OrphanAwarePageManager::new(manager, orphan_manager);
+
+        let mut page = orphan_aware_manager.allocate(1).unwrap();
+        assert_eq!(page.id, 0);
+        assert_eq!(page.contents()[0], 0);
+        assert_eq!(page.snapshot_id(), 1);
+
+        page.contents_mut()[0] = 123;
+
+        orphan_aware_manager.commit(1).unwrap();
+
+        let page = orphan_aware_manager.get(1, 0).unwrap();
+        assert_eq!(page.id, 0);
+        assert_eq!(page.contents()[0], 123);
+        assert_eq!(page.snapshot_id(), 1);
+
+        // cloning a page should allocate a new page and orphan the original page.
+        let page = orphan_aware_manager.get_mut_clone(2, 0).unwrap();
+        assert_eq!(page.id, 1);
+        assert_eq!(page.contents()[0], 123);
+        assert_eq!(page.snapshot_id(), 2);
+
+        // the next allocation should not come from the orphaned page, as the snapshot id is the same as when the page was orphaned.
+        let page = orphan_aware_manager.allocate(2).unwrap();
+        assert_eq!(page.id, 2);
+        assert_eq!(page.contents()[0], 0);
+        assert_eq!(page.snapshot_id(), 2);
+
+        orphan_aware_manager.commit(2).unwrap();
+
+        // the next allocation should come from the orphaned page because the snapshot id has increased.
+        // The page data should be zeroed out.
+        let page = orphan_aware_manager.allocate(3).unwrap();
+        assert_eq!(page.id, 0);
+        assert_eq!(page.contents()[0], 0);
+        assert_eq!(page.snapshot_id(), 3);
+    }
+}

--- a/src/page/orphan.rs
+++ b/src/page/orphan.rs
@@ -1,0 +1,96 @@
+use std::collections::BTreeMap;
+use crate::snapshot::SnapshotId;
+use crate::page::PageId;
+
+// Manages a collection of orphaned page ids, grouped by the snapshot id which created them.
+#[derive(Debug)]
+pub struct OrphanPageManager {
+    orphaned_page_ids: BTreeMap<SnapshotId, Vec<PageId>>,
+}
+
+impl OrphanPageManager {
+    // Creates a new OrphanPageManager.
+    pub fn new() -> Self {
+        Self { orphaned_page_ids: BTreeMap::new() }
+    }
+
+    // Returns the page id of a page that was orphaned as of the given snapshot id.
+    // If there are no orphaned pages as of the given snapshot id, None is returned.
+    pub fn get_orphaned_page_id(&mut self, max_snapshot_id: SnapshotId) -> Option<PageId> {
+        let (snapshot_id, pages) = self.orphaned_page_ids.iter_mut().find(|(k, _)| **k <= max_snapshot_id)?;
+        let page_id = pages.pop();
+        if pages.is_empty() {
+            let to_remove = *snapshot_id;
+            self.orphaned_page_ids.remove(&to_remove);
+        }
+        page_id
+    }
+
+    // Adds a single page id to the orphaned page ids for the given snapshot id.
+    pub fn add_orphaned_page_id(&mut self, snapshot_id: SnapshotId, page_id: PageId) {
+        self.add_orphaned_page_ids(snapshot_id, vec![page_id]);
+    }
+
+    // Adds a collection of page ids to the orphaned page ids for the given snapshot id.
+    pub fn add_orphaned_page_ids(&mut self, snapshot_id: SnapshotId, pages: impl IntoIterator<Item = PageId>) {
+        self.orphaned_page_ids.entry(snapshot_id).or_insert(vec![]).extend(pages);
+    }
+
+    // Returns an iterator over all the orphaned page ids.
+    pub fn iter(&self) -> impl Iterator<Item = &PageId> {
+        self.orphaned_page_ids.values().flat_map(|pages| pages.iter())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_orphaned_page_id() {
+        let mut manager = OrphanPageManager::new();
+        manager.add_orphaned_page_id(42, 0);
+        assert_eq!(manager.get_orphaned_page_id(42), Some(0));
+        assert_eq!(manager.get_orphaned_page_id(42), None);
+    }
+
+    #[test]
+    fn test_add_orphaned_page_ids() {
+        let mut manager = OrphanPageManager::new();
+        manager.add_orphaned_page_ids(42, vec![0, 1, 2]);
+        assert_eq!(manager.get_orphaned_page_id(42), Some(2));
+        assert_eq!(manager.get_orphaned_page_id(42), Some(1));
+        assert_eq!(manager.get_orphaned_page_id(42), Some(0));
+        assert_eq!(manager.get_orphaned_page_id(42), None);
+    }
+
+    #[test]
+    fn test_get_orphaned_page_id_with_multiple_snapshots() {
+        let mut manager = OrphanPageManager::new();
+        manager.add_orphaned_page_id(42, 0);
+        manager.add_orphaned_page_id(43, 1);
+        manager.add_orphaned_page_id(44, 2);
+        assert_eq!(manager.get_orphaned_page_id(42), Some(0));
+        assert_eq!(manager.get_orphaned_page_id(42), None);
+        assert_eq!(manager.get_orphaned_page_id(43), Some(1));
+        assert_eq!(manager.get_orphaned_page_id(43), None);
+
+        let mut manager = OrphanPageManager::new();
+        manager.add_orphaned_page_id(42, 0);
+        manager.add_orphaned_page_id(43, 1);
+        manager.add_orphaned_page_id(44, 2);
+        assert_eq!(manager.get_orphaned_page_id(43), Some(0));
+        assert_eq!(manager.get_orphaned_page_id(43), Some(1));
+        assert_eq!(manager.get_orphaned_page_id(43), None);
+        assert_eq!(manager.get_orphaned_page_id(42), None);
+    }
+
+    #[test]
+    fn test_iter() {
+        let mut manager = OrphanPageManager::new();
+        manager.add_orphaned_page_ids(42, vec![0, 1, 2]);
+        manager.add_orphaned_page_ids(999, vec![100, 101, 102]);
+        let orphaned_page_ids: Vec<PageId> = manager.iter().copied().collect();
+        assert_eq!(orphaned_page_ids, vec![0, 1, 2, 100, 101, 102]);
+    }
+}

--- a/src/page/page.rs
+++ b/src/page/page.rs
@@ -1,8 +1,62 @@
-mod page;
+use crate::snapshot::SnapshotId;
+use crate::page::PageId;
 
 pub const PAGE_SIZE: usize = 4096;
+pub const HEADER_SIZE: usize = 8;
+pub const PAGE_DATA_SIZE: usize = PAGE_SIZE - HEADER_SIZE;
 
+// Represents a page in the database.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Page<'p> {
+    pub id: PageId,
+    data: &'p [u8; PAGE_SIZE],
+    snapshot_id: SnapshotId,
+}
+
+impl<'p> Page<'p> {
+    // Creates a new Page with the given id, snapshot id, and data.
+    pub fn new(id: PageId, data: &'p [u8; PAGE_SIZE]) -> Self {
+        let snapshot_id = u64::from_le_bytes(data[0..8].try_into().unwrap());
+        Self { id, snapshot_id, data }
+    }
+
+    // Returns the snapshot id of the page.
+    pub fn snapshot_id(&self) -> SnapshotId {
+        self.snapshot_id
+    }
+
+    // Returns the contents of the page without the header
+    pub fn contents(&self) -> &'p [u8] {
+        &self.data[HEADER_SIZE..]
+    }
+}
+
+// Represents a mutable handle to a page in the database.
 #[derive(Debug, PartialEq, Eq)]
-pub struct Page<'a> {
-    data: &'a mut [u8; PAGE_SIZE],
+pub struct PageMut<'p> {
+    pub id: PageId,
+    data: &'p mut [u8; PAGE_SIZE],
+    snapshot_id: SnapshotId,
+}
+
+impl<'p> PageMut<'p> {
+    // Creates a new PageMut with the given id, snapshot id, and data.
+    pub fn new(id: PageId, snapshot_id: SnapshotId, data: &'p mut [u8; PAGE_SIZE]) -> Self {
+        data[0..8].copy_from_slice(&snapshot_id.to_le_bytes());
+        Self { id, snapshot_id, data }
+    }
+
+    // Returns the snapshot id of the page.
+    pub fn snapshot_id(&self) -> SnapshotId {
+        self.snapshot_id
+    }
+
+    // Returns the contents of the page without the header
+    pub fn contents(&self) -> &[u8] {
+        &self.data[HEADER_SIZE..]
+    }
+
+    pub fn contents_mut(&mut self) -> &mut [u8] {
+        &mut self.data[HEADER_SIZE..]
+    }
 }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1,0 +1,2 @@
+/// TODO: potentially use a a more sophisticated snapshotting mechanism that requires a Snapshot struct to carry more context.
+pub type SnapshotId = u64;


### PR DESCRIPTION
Updates the `Page` and `PageManager` interfaces to represent the Copy-on-Write page abstraction.

* Splits `Page` into `Page` and `PageMut`
* Adds `PageManager` methods for `get_mut` and `get_mut_clone`
* Removes `PageManager` methods related to `split`, `merge`, and `write` for now, which are higher-level operations that require understanding of the trie nodes.

Implements memory-mapped `PageManager` as well as an `OrphanAwarePageManager` which wraps a `PageManager` such as the `MmapPageManager` and attempts to add to / allocate from the orphan list as pages are cloned for writing.

Adds a general snapshot-based in-memory orphan manager