### PR TITLE
fix: prevent cell overlap in out-of-order defragmentation

### DIFF
--- a/src/page/slotted_page.rs
+++ b/src/page/slotted_page.rs
@@ -959,29 +959,30 @@ mod tests {
 
         slotted_page.defragment(5, 595).unwrap();
 
+        // (id, offset, length)
         let expected_cell_pointers = [
-            (595, 595),
-            (762, 167),
-            (1097, 168),
-            (929, 167),
-            (0, 0),
-            (1265, 168),
-            (1433, 168),
-            (1600, 167),
-            (1767, 167),
-            (1935, 168),
-            (2270, 167),
-            (2103, 168),
-            (3366, 167),
-            (3199, 595),
-            (2437, 167),
-            (2604, 167),
+            (4, 0, 0),
+            (0, 595, 595),
+            (1, 762, 167),
+            (3, 929, 167),
+            (2, 1097, 168),
+            (5, 1265, 168),
+            (6, 1433, 168),
+            (7, 1600, 167),
+            (8, 1767, 167),
+            (9, 1935, 168),
+            (11, 2103, 168),
+            (10, 2270, 167),
+            (14, 2437, 167),
+            (15, 2604, 167),
+            (13, 3199, 595),
+            (12, 3366, 167),
         ];
 
         assert_eq!(slotted_page.num_cells(), expected_cell_pointers.len() as u8);
 
-        for (index, (offset, length)) in expected_cell_pointers.iter().enumerate() {
-            let cell_pointer = slotted_page.get_cell_pointer(index as u8).unwrap();
+        for (index, offset, length) in expected_cell_pointers.iter() {
+            let cell_pointer = slotted_page.get_cell_pointer(*index as u8).unwrap();
             assert_eq!(cell_pointer.offset(), *offset);
             assert_eq!(cell_pointer.length(), *length);
         }

--- a/src/page/slotted_page.rs
+++ b/src/page/slotted_page.rs
@@ -243,7 +243,7 @@ impl<'p> SlottedPage<'p, RW> {
 
         let mut last_start = 0;
         let mut last_offset = 0;
-        for (id, offset, len) in cell_pointers {
+        for (idx, offset, len) in cell_pointers {
             let start = offset - len;
             if start == last_start {
                 last_offset = offset;
@@ -254,7 +254,7 @@ impl<'p> SlottedPage<'p, RW> {
             let end_index = start_index + len as usize;
 
             let new_offset = last_offset + len;
-            self.set_cell_pointer(id as u8, new_offset, len)?;
+            self.set_cell_pointer(idx as u8, new_offset, len)?;
 
             let new_start_index = (PAGE_DATA_SIZE as u16 - new_offset) as usize;
             self.page
@@ -959,32 +959,31 @@ mod tests {
 
         slotted_page.defragment(5, 595).unwrap();
 
-        // (id, offset, length)
         let expected_cell_pointers = [
-            (4, 0, 0),
-            (0, 595, 595),
-            (1, 762, 167),
-            (3, 929, 167),
-            (2, 1097, 168),
-            (5, 1265, 168),
-            (6, 1433, 168),
-            (7, 1600, 167),
-            (8, 1767, 167),
-            (9, 1935, 168),
-            (11, 2103, 168),
-            (10, 2270, 167),
-            (14, 2437, 167),
-            (15, 2604, 167),
-            (13, 3199, 595),
-            (12, 3366, 167),
+            (595, 595),
+            (762, 167),
+            (1097, 168),
+            (929, 167),
+            (0, 0),
+            (1265, 168),
+            (1433, 168),
+            (1600, 167),
+            (1767, 167),
+            (1935, 168),
+            (2270, 167),
+            (2103, 168),
+            (3366, 167),
+            (3199, 595),
+            (2437, 167),
+            (2604, 167),
         ];
 
         assert_eq!(slotted_page.num_cells(), expected_cell_pointers.len() as u8);
 
-        for (index, offset, length) in expected_cell_pointers.iter() {
-            let cell_pointer = slotted_page.get_cell_pointer(*index as u8).unwrap();
-            assert_eq!(cell_pointer.offset(), *offset);
-            assert_eq!(cell_pointer.length(), *length);
+        for (idx, (offset, length)) in expected_cell_pointers.into_iter().enumerate() {
+            let cell_pointer = slotted_page.get_cell_pointer(idx as u8).unwrap();
+            assert_eq!(cell_pointer.offset(), offset);
+            assert_eq!(cell_pointer.length(), length);
         }
     }
 }

--- a/src/page/slotted_page.rs
+++ b/src/page/slotted_page.rs
@@ -230,20 +230,20 @@ impl<'p> SlottedPage<'p, RW> {
             return Ok(false);
         }
 
-        // (id, len, offset)
+        // (id, offset, length)
         let mut cell_pointers = self
             .cell_pointers_iter()
             .enumerate()
             .filter(|(_, cp)| !cp.is_deleted())
-            .map(|(i, cp)| (i, cp.length(), cp.offset()))
+            .map(|(i, cp)| (i, cp.offset(), cp.length()))
             .collect::<Vec<_>>();
 
         // sort by offset
-        cell_pointers.sort_by(|a, b| a.2.cmp(&b.2));
+        cell_pointers.sort_by(|a, b| a.1.cmp(&b.1));
 
         let mut last_start = 0;
         let mut last_offset = 0;
-        for (id, len, offset) in cell_pointers {
+        for (id, offset, len) in cell_pointers {
             let start = offset - len;
             if start == last_start {
                 last_offset = offset;


### PR DESCRIPTION
Added intentionally failing test case to highlight an issue with defragmentation of a page where cells are not strictly in right-to-left order in the page. This currently causes the resulting cells to overlap