### PR TITLE
fix: prevent cell overlap in out of order defragmentation

### DIFF
--- a/src/page/slotted_page.rs
+++ b/src/page/slotted_page.rs
@@ -230,7 +230,6 @@ impl<'p> SlottedPage<'p, RW> {
             return Ok(false);
         }
 
-        // (id, offset, length)
         let mut cell_pointers = self
             .cell_pointers_iter()
             .enumerate()
@@ -951,9 +950,9 @@ mod tests {
             (3200, 167),
         ];
 
-        for (index, (offset, length)) in initial_cell_pointers.iter().enumerate() {
+        for (idx, (offset, length)) in initial_cell_pointers.iter().enumerate() {
             slotted_page
-                .set_cell_pointer(index as u8, *offset, *length)
+                .set_cell_pointer(idx as u8, *offset, *length)
                 .unwrap();
         }
 

--- a/src/page/slotted_page.rs
+++ b/src/page/slotted_page.rs
@@ -923,4 +923,67 @@ mod tests {
             String::from_iter(&['e'; 814])
         );
     }
+
+    #[test]
+    fn test_defragment_page_cells_out_of_order() {
+        let mut data = [0; PAGE_SIZE];
+        let page = Page::new_rw_with_snapshot(42, 123, &mut data);
+        let mut slotted_page = SlottedPage::<RW>::try_from(page).unwrap();
+
+        slotted_page.set_num_cells(16);
+
+        let initial_cell_pointers = [
+            (595, 595),
+            (762, 167),
+            (1358, 168),
+            (929, 167),
+            (0, 0),
+            (1860, 168),
+            (2028, 168),
+            (2195, 167),
+            (2362, 167),
+            (2530, 168),
+            (2865, 167),
+            (2698, 168),
+            (3962, 167),
+            (3795, 595),
+            (3033, 167),
+            (3200, 167),
+        ];
+
+        for (index, (offset, length)) in initial_cell_pointers.iter().enumerate() {
+            slotted_page
+                .set_cell_pointer(index as u8, *offset, *length)
+                .unwrap();
+        }
+
+        slotted_page.defragment(5, 595).unwrap();
+
+        let expected_cell_pointers = [
+            (595, 595),
+            (762, 167),
+            (1097, 168),
+            (929, 167),
+            (0, 0),
+            (1265, 168),
+            (1433, 168),
+            (1600, 167),
+            (1767, 167),
+            (1935, 168),
+            (2270, 167),
+            (2103, 168),
+            (3366, 167),
+            (3199, 595),
+            (2437, 167),
+            (2604, 167),
+        ];
+
+        assert_eq!(slotted_page.num_cells(), expected_cell_pointers.len() as u8);
+
+        for (idx, (offset, length)) in expected_cell_pointers.into_iter().enumerate() {
+            let cell_pointer = slotted_page.get_cell_pointer(idx as u8).unwrap();
+            assert_eq!(cell_pointer.offset(), offset);
+            assert_eq!(cell_pointer.length(), length);
+        }
+    }
 }


### PR DESCRIPTION
Fix the issue of defragmentation when cells are not in order, the data copying based on idx order could lead to overwriting cell data and cell overlapping 