### PR TITLE
feat: Proactively split pages to avoid undefined behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,7 +557,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -823,7 +835,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -867,7 +879,7 @@ dependencies = [
  "lazy_static",
  "num-traits",
  "rand 0.8.5",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -916,8 +928,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.2",
+ "zerocopy 0.8.20",
 ]
 
 [[package]]
@@ -928,6 +951,16 @@ checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.2",
 ]
 
 [[package]]
@@ -951,7 +984,17 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a509b1a2ffbe92afab0e55c8fd99dea1c280e8171bd2d88682bb20bc41cbc2c"
+dependencies = [
+ "getrandom 0.3.1",
+ "zerocopy 0.8.20",
 ]
 
 [[package]]
@@ -1282,7 +1325,7 @@ checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1362,6 +1405,7 @@ dependencies = [
  "alloy-trie",
  "log",
  "memmap2",
+ "rand 0.9.0",
  "sealed",
  "tempdir",
 ]
@@ -1434,6 +1478,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "winapi"
@@ -1540,6 +1593,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1555,7 +1617,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde3bb8c68a8f3f1ed4ac9221aad6b10cece3e60a8e2ea54a6a2dec806d0084c"
+dependencies = [
+ "zerocopy-derive 0.8.20",
 ]
 
 [[package]]
@@ -1563,6 +1634,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea57037071898bf96a6da35fd626f4f27e9cee3ead2a6c703cf09d472b2e700"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,5 @@ memmap2 = "0.9.5"
 sealed = "0.6.0"
 
 [dev-dependencies]
+rand = "0.9.0"
 tempdir = "0.3.7"

--- a/src/node.rs
+++ b/src/node.rs
@@ -5,7 +5,6 @@ use alloy_trie::{
 };
 
 use crate::{
-    account::AccountVec,
     pointer::Pointer,
     storage::value::{self, Value},
 };

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,7 +1,7 @@
 use alloy_primitives::{keccak256, Address, StorageKey};
 use alloy_trie::Nibbles;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct AddressPath {
     path: Nibbles,
 }

--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -4,7 +4,8 @@ use crate::{
     location::Location,
     node::{LeafType, Node},
     page::{
-        OrphanPageManager, Page, PageError, PageId, PageManager, RootPage, SlottedPage, RO, RW,
+        OrphanPageManager, Page, PageError, PageId, PageManager, RootPage, SlottedPage,
+        PAGE_DATA_SIZE, RO, RW,
     },
     path::{AddressPath, StoragePath},
     pointer::Pointer,
@@ -266,32 +267,19 @@ impl<P: PageManager> StorageEngine<P> {
         );
         match result {
             Ok(pointer) => Ok(pointer),
+            // In the case of a page split, re-attempt the operation from scratch. This ensures that a page will be
+            // consistently evaluated, and not modified in the middle of an operation, which could result in
+            // inconsistent cell pointers.
+            Err(Error::PageSplit) => self.set_value_in_cloned_page(
+                metadata,
+                path,
+                value,
+                &mut new_slotted_page,
+                page_index,
+                leaf_type,
+            ),
             Err(Error::PageError(PageError::PageIsFull)) => {
-                // Re-clone the page, split it, and try again. This orphans the first clone.
-                // TODO: it's probably better if we can proactively split the page instead of needing this fallback behavior.
-                // This would also allow us to avoid cloning the path and account.
-                {
-                    self.inner
-                        .write()
-                        .unwrap()
-                        .orphan_manager
-                        .add_orphaned_page_id(metadata.snapshot_id, new_slotted_page.page_id());
-                }
-                let page = self.get_mut_clone(metadata, page_id)?;
-                let mut new_slotted_page = SlottedPage::try_from(page)?;
-                self.split_page::<V>(metadata, &mut new_slotted_page)
-                    .expect("split page should succeed");
-                let pointer = self
-                    .set_value_in_cloned_page(
-                        metadata,
-                        path,
-                        value,
-                        &mut new_slotted_page,
-                        page_index,
-                        leaf_type,
-                    )
-                    .expect("set account in cloned page should succeed");
-                Ok(pointer)
+                panic!("Page is full!");
             }
             Err(e) => Err(e),
         }
@@ -325,6 +313,12 @@ impl<P: PageManager> StorageEngine<P> {
         let common_prefix = path.slice(0..common_prefix_length);
         if common_prefix_length < node.prefix().len() {
             // the path does not match the node prefix, so we need to create a new branch node as its parent.
+            // ensure that the page has enough space (1100 bytes) to insert a new branch and leaf node.
+            // TODO: use a more accurate threshold
+            if slotted_page.num_free_bytes() < 1100 {
+                self.split_page::<V>(metadata, slotted_page)?;
+                return Err(Error::PageSplit);
+            }
             let mut new_parent_branch: Node<V> = Node::new_branch(common_prefix);
             let child_branch_index = path[common_prefix_length];
             let remaining_path = path.slice(common_prefix_length + 1..);
@@ -440,6 +434,12 @@ impl<P: PageManager> StorageEngine<P> {
             }
             None => {
                 // the child node does not exist, so we need to create a new leaf node with the remaining path.
+                // ensure that the page has enough space (300 bytes) to insert a new leaf node.
+                // TODO: use a more accurate threshold
+                if slotted_page.num_free_bytes() < 300 {
+                    self.split_page::<V>(metadata, slotted_page)?;
+                    return Err(Error::PageSplit);
+                }
                 let new_node = Node::new_leaf(remaining_path, value, leaf_type);
                 let rlp_node = new_node.rlp_encode();
                 let location = Location::for_cell(slotted_page.insert_value(new_node)?);
@@ -510,40 +510,44 @@ impl<P: PageManager> StorageEngine<P> {
         metadata: &mut Metadata,
         page: &mut SlottedPage<'_, RW>,
     ) -> Result<(), Error> {
-        let child_page = self.allocate_page(metadata)?;
-        let mut child_slotted_page = SlottedPage::try_from(child_page)?;
+        while page.num_free_bytes() < PAGE_DATA_SIZE / 3 as usize {
+            let child_page = self.allocate_page(metadata)?;
+            let mut child_slotted_page = SlottedPage::try_from(child_page)?;
 
-        let mut root_node: Node<V> = page.get_value(0)?;
+            let mut root_node: Node<V> = page.get_value(0)?;
 
-        // Find the child with the largest subtrie
-        let (largest_child_index, largest_child_pointer) = root_node
-            .enumerate_children()
-            .into_iter()
-            .max_by_key(|(_, ptr)| {
-                // If pointer points to a cell in current page, count nodes in that subtrie
-                if let Some(cell_index) = ptr.location().cell_index() {
-                    self.count_subtrie_nodes::<V>(page, cell_index).unwrap_or(0)
-                } else {
-                    // If pointer points to another page, count as 0
-                    0
-                }
-            })
-            .ok_or(Error::PageError(PageError::PageIsFull))?;
+            // Find the child with the largest subtrie
+            let (largest_child_index, largest_child_pointer) = root_node
+                .enumerate_children()
+                .into_iter()
+                .max_by_key(|(_, ptr)| {
+                    // If pointer points to a cell in current page, count nodes in that subtrie
+                    if let Some(cell_index) = ptr.location().cell_index() {
+                        self.count_subtrie_nodes::<V>(page, cell_index).unwrap_or(0)
+                    } else {
+                        // If pointer points to another page, count as 0
+                        0
+                    }
+                })
+                .ok_or(Error::PageError(PageError::PageIsFull))?;
 
-        // Move the subtrie to the new page
-        if let Some(cell_index) = largest_child_pointer.location().cell_index() {
-            // Move all child nodes that are in the current page
-            self.move_subtrie_nodes::<V>(page, cell_index, &mut child_slotted_page)?;
+            // Move the subtrie to the new page
+            if let Some(cell_index) = largest_child_pointer.location().cell_index() {
+                // Move all child nodes that are in the current page
+                let location =
+                    self.move_subtrie_nodes::<V>(page, cell_index, &mut child_slotted_page)?;
+                assert!(
+                    location.page_id().is_some(),
+                    "expected subtrie to be moved to a new page"
+                );
 
-            // Update the pointer in the root node to point to the new page
-            root_node.set_child(
-                largest_child_index as u8,
-                Pointer::new(
-                    Location::for_page(child_slotted_page.page_id()),
-                    largest_child_pointer.rlp().clone(),
-                ),
-            );
-            page.set_value(0, root_node)?;
+                // Update the pointer in the root node to point to the new page
+                root_node.set_child(
+                    largest_child_index as u8,
+                    Pointer::new(location, largest_child_pointer.rlp().clone()),
+                );
+                page.set_value(0, root_node)?;
+            }
         }
 
         Ok(())
@@ -588,7 +592,7 @@ impl<P: PageManager> StorageEngine<P> {
 
         // if the node has no children, we're done.
         if !has_children {
-            return Ok(Location::for_cell(new_index));
+            return Ok(self.node_location(target_page.page_id(), new_index));
         }
 
         // otherwise, we need to move the children of the node.
@@ -785,6 +789,7 @@ pub enum Error {
     InvalidPath,
     InvalidSnapshotId,
     EngineClosed,
+    PageSplit,
 }
 
 impl From<PageError> for Error {
@@ -1308,6 +1313,316 @@ mod tests {
 
             let storage_root = account.storage_root();
             assert_eq!(storage_root, expected_root);
+        }
+    }
+
+    fn test_split_page_stress() {
+        // Create a storage engine with limited pages to force splits
+        let (storage_engine, mut metadata) = create_test_engine(2000, 256);
+
+        // Create a large number of accounts with different patterns to stress the trie
+
+        // Pattern 1: Accounts with common prefixes to create deep branches
+        let mut accounts = Vec::new();
+        for i in 0..4096 {
+            // Create paths with common prefixes but different endings
+            let mut nibbles = [0u8; 64];
+            // First 32 nibbles are the same
+            for j in 0..32 {
+                nibbles[j] = (j % 16) as u8;
+            }
+            // Last 30 nibbles vary
+            for j in 32..64 {
+                nibbles[j] = ((i + j) % 16) as u8;
+            }
+
+            nibbles[61] = (i % 16) as u8;
+            nibbles[62] = ((i / 16) % 16) as u8;
+            nibbles[63] = ((i / 256) % 16) as u8;
+
+            let path = AddressPath::new(Nibbles::from_nibbles(nibbles));
+            let account = create_test_account(i as u64 * 1000, i as u64);
+            accounts.push((path, account));
+        }
+
+        // Pattern 2: Accounts with very different paths to create wide branches
+        for i in 0..4096 {
+            let mut nibbles = [0u8; 64];
+            // Make each path start with a different nibble
+            nibbles[0] = (i % 16) as u8;
+            nibbles[1] = ((i / 16) % 16) as u8;
+            nibbles[2] = ((i / 256) % 16) as u8;
+            // Fill the rest with a pattern
+            for j in 3..64 {
+                nibbles[j] = ((i * j) % 16) as u8;
+            }
+
+            let path = AddressPath::new(Nibbles::from_nibbles(nibbles));
+            let account = create_test_account(i as u64 * 2000, i as u64 * 2);
+            accounts.push((path, account));
+        }
+
+        // Pattern 3: Accounts with paths that will cause specific branch splits
+        for i in 0..4096 {
+            let mut nibbles = [0u8; 64];
+            // First half of paths share prefix, second half different
+            if i < 50 {
+                nibbles[0] = 10; // Arbitrary value
+                for j in 1..62 {
+                    nibbles[j] = ((i + j) % 16) as u8;
+                }
+            } else {
+                nibbles[0] = 11; // Different arbitrary value
+                for j in 1..62 {
+                    nibbles[j] = ((i + j) % 16) as u8;
+                }
+            }
+
+            nibbles[61] = (i % 16) as u8;
+            nibbles[62] = ((i / 16) % 16) as u8;
+            nibbles[63] = ((i / 256) % 16) as u8;
+
+            let path = AddressPath::new(Nibbles::from_nibbles(nibbles));
+            let account = create_test_account(i as u64 * 3000, i as u64 * 3);
+            accounts.push((path, account));
+        }
+
+        // Ensure there are no duplicate paths
+        let mut unique_paths = std::collections::HashSet::new();
+        for (path, _) in &accounts {
+            assert!(
+                unique_paths.insert(path.clone()),
+                "Duplicate path found: {:?}",
+                path
+            );
+        }
+
+        // Insert all accounts
+        for (path, account) in &accounts {
+            storage_engine
+                .set_account(&mut metadata, path.clone(), Some(account.clone()))
+                .unwrap();
+        }
+
+        // Verify all accounts exist with correct values
+        for (path, expected_account) in &accounts {
+            let retrieved_account = storage_engine
+                .get_account::<AccountVec>(&metadata, path.clone())
+                .unwrap();
+            assert_eq!(
+                retrieved_account,
+                Some(expected_account.clone()),
+                "Account mismatch for path: {:?}",
+                path
+            );
+        }
+
+        // Force multiple splits to stress the system
+        // Find all pages in the trie and split them recursively
+        let mut pages_to_split = vec![metadata.root_subtrie_page_id];
+        while let Some(page_id) = pages_to_split.pop() {
+            let page_result = storage_engine.get_mut_page(&metadata, page_id);
+            if matches!(
+                page_result,
+                Err(Error::PageError(PageError::PageNotFound(_)))
+            ) {
+                break;
+            }
+            let mut slotted_page = SlottedPage::try_from(page_result.unwrap()).unwrap();
+
+            // Try to split this page
+            if let Ok(_) = storage_engine.split_page::<AccountVec>(&mut metadata, &mut slotted_page)
+            {
+                // If split succeeded, add the new pages to be processed
+                pages_to_split.push(page_id + 1); // New page created by split
+            }
+        }
+
+        // Verify all accounts still exist with correct values after splits
+        for (path, expected_account) in &accounts {
+            let retrieved_account = storage_engine
+                .get_account::<AccountVec>(&metadata, path.clone())
+                .unwrap();
+            assert_eq!(
+                retrieved_account,
+                Some(expected_account.clone()),
+                "Account mismatch after split for path: {:?}",
+                path
+            );
+        }
+
+        // Add more accounts after splitting to ensure the structure is still valid
+        let mut additional_accounts = Vec::new();
+        for i in 0..50 {
+            let mut nibbles = [0u8; 64];
+            // Create some completely new paths
+            nibbles[0] = 15; // Different from previous patterns
+            for j in 1..62 {
+                nibbles[j] = ((i * j + 7) % 16) as u8; // Different pattern
+            }
+
+            nibbles[62] = (i % 16) as u8;
+            nibbles[63] = ((i / 16) % 16) as u8;
+
+            let path = AddressPath::new(Nibbles::from_nibbles(nibbles));
+            let account = create_test_account(i as u64 * 5000, i as u64 * 5);
+            additional_accounts.push((path, account));
+        }
+
+        // Insert additional accounts
+        for (path, account) in &additional_accounts {
+            storage_engine
+                .set_account(&mut metadata, path.clone(), Some(account.clone()))
+                .unwrap();
+        }
+
+        // Verify all original accounts still exist
+        for (path, expected_account) in &accounts {
+            let retrieved_account = storage_engine
+                .get_account::<AccountVec>(&metadata, path.clone())
+                .unwrap();
+            assert_eq!(
+                retrieved_account,
+                Some(expected_account.clone()),
+                "Original account lost after adding new accounts"
+            );
+        }
+
+        // Verify all new accounts exist
+        for (path, expected_account) in &additional_accounts {
+            let retrieved_account = storage_engine
+                .get_account::<AccountVec>(&metadata, path.clone())
+                .unwrap();
+            assert_eq!(
+                retrieved_account,
+                Some(expected_account.clone()),
+                "New account not found"
+            );
+        }
+    }
+
+    #[test]
+    fn test_split_page_random_accounts() {
+        use rand::rngs::StdRng;
+        use rand::{Rng, SeedableRng};
+
+        // Create a storage engine
+        let (storage_engine, mut metadata) = create_test_engine(2000, 256);
+
+        // Use a seeded RNG for reproducibility
+        let mut rng = StdRng::seed_from_u64(42);
+
+        // Generate a large number of random accounts
+        let mut accounts = Vec::new();
+        for i in 0..3000 {
+            let mut nibbles = [0u8; 64];
+            // Generate random nibbles
+            for j in 0..64 {
+                nibbles[j] = rng.random_range(0..16) as u8;
+            }
+
+            let path = AddressPath::new(Nibbles::from_nibbles(nibbles));
+            let balance = rng.random_range(0..1_000_000);
+            let nonce = rng.random_range(0..100);
+            let account = create_test_account(balance, nonce);
+            accounts.push((path, account));
+        }
+
+        // Insert all accounts
+        for (path, account) in &accounts {
+            storage_engine
+                .set_account(&mut metadata, path.clone(), Some(account.clone()))
+                .unwrap();
+        }
+
+        // Verify all accounts exist with correct values
+        for (path, expected_account) in &accounts {
+            let retrieved_account = storage_engine
+                .get_account::<AccountVec>(&metadata, path.clone())
+                .unwrap();
+            assert_eq!(retrieved_account, Some(expected_account.clone()));
+        }
+
+        // Get all pages and force splits on them
+        let mut page_ids = Vec::new();
+        // Start with the root page
+        page_ids.push(metadata.root_subtrie_page_id);
+
+        // Process each page
+        for i in 0..page_ids.len() {
+            let page_id = page_ids[i];
+
+            // Try to get and split the page
+            if let Ok(page) = storage_engine.get_mut_page(&metadata, page_id) {
+                if let Ok(mut slotted_page) = SlottedPage::try_from(page) {
+                    // Force a split
+                    let _ =
+                        storage_engine.split_page::<AccountVec>(&mut metadata, &mut slotted_page);
+
+                    // Get the node to find child pages
+                    if let Ok(node) = slotted_page.get_value::<Node<AccountVec>>(0) {
+                        // Add child pages to our list
+                        for (_, child_ptr) in node.enumerate_children() {
+                            if let Some(child_page_id) = child_ptr.location().page_id() {
+                                if !page_ids.contains(&child_page_id) {
+                                    page_ids.push(child_page_id);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Verify all accounts still exist with correct values after splits
+        for (path, expected_account) in &accounts {
+            let retrieved_account = storage_engine
+                .get_account::<AccountVec>(&metadata, path.clone())
+                .unwrap();
+            assert_eq!(
+                retrieved_account,
+                Some(expected_account.clone()),
+                "Account mismatch after splitting multiple pages"
+            );
+        }
+
+        // Create a vector to store updates
+        let mut updates = Vec::new();
+
+        // Prepare updates for some existing accounts
+        for i in 0..accounts.len() {
+            if i % 5 == 0 {
+                // Update every 5th account
+                let (path, _) = &accounts[i];
+                let new_balance = rng.random_range(0..1_000_000);
+                let new_nonce = rng.random_range(0..100);
+                let new_account = create_test_account(new_balance, new_nonce);
+
+                updates.push((i, path.clone(), new_account));
+            }
+        }
+
+        // Apply the updates to both the trie and our test data
+        for (idx, path, new_account) in &updates {
+            // Update in the trie
+            storage_engine
+                .set_account(&mut metadata, path.clone(), Some(new_account.clone()))
+                .unwrap();
+
+            // Update in our test data
+            accounts[*idx] = (path.clone(), new_account.clone());
+        }
+
+        // Verify all accounts have correct values after updates
+        for (path, expected_account) in &accounts {
+            let retrieved_account = storage_engine
+                .get_account::<AccountVec>(&metadata, path.clone())
+                .unwrap();
+            assert_eq!(
+                retrieved_account,
+                Some(expected_account.clone()),
+                "Account mismatch after updates"
+            );
         }
     }
 


### PR DESCRIPTION
Revises the page splitting behavior to split ahead of making any changes to the page. If not enough space is detected in the page before performing an insertion, a split is performed and a PageSplit error is thrown, allowing the entire page-wise operation to be retried without any partially-applied changes.

This prevents the previously poorly-defined behavior caused by attempting to revert any incomplete changes by re-cloning the initial page.

This uses some arbitrary byte thresholds which will need to be updated, and should ideally be more precise.