### PR TITLE
feat: add metrics for transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,27 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "alloy-primitives"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,6 +733,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a7deb012b3b2767169ff203fadb4c6b0b82b947512e5eb9e0b78c2e186ad9e3"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3dbdd96ed57d565ec744cba02862d707acf373c5772d152abae6ec5c4e24f6c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -816,6 +859,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
 name = "ppv-lite86"
@@ -970,6 +1019,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 dependencies = [
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1362,6 +1434,8 @@ dependencies = [
  "alloy-trie",
  "log",
  "memmap2",
+ "metrics",
+ "metrics-derive",
  "sealed",
  "tempdir",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ alloy-rlp = "0.3.11"
 alloy-trie = "0.7.6"
 log = "0.4.25"
 memmap2 = "0.9.5"
+metrics = "0.24.1"
+metrics-derive = "0.1.0"
 sealed = "0.6.0"
 
 [dev-dependencies]

--- a/src/database.rs
+++ b/src/database.rs
@@ -62,6 +62,10 @@ impl Metadata {
         self.transaction_metrics.borrow_mut().pages_allocated += 1;
     }
 
+    pub fn metrics_inc_pages_reallocated(&self) {
+        self.transaction_metrics.borrow_mut().pages_reallocated += 1;
+    }
+
     pub fn metrics_pages_read_get_reset(&self) -> u32 {
         let mut metrics = self.transaction_metrics.borrow_mut();
         let pages_read = metrics.pages_read;
@@ -81,6 +85,13 @@ impl Metadata {
         let pages_allocated = metrics.pages_allocated;
         metrics.pages_allocated = 0;
         pages_allocated
+    }
+
+    pub fn metrics_pages_reallocated_get_reset(&self) -> u32 {
+        let mut metrics = self.transaction_metrics.borrow_mut();
+        let pages_reallocated = metrics.pages_reallocated;
+        metrics.pages_reallocated = 0;
+        pages_reallocated
     }
 }
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -35,7 +35,7 @@ pub(crate) struct Metadata {
     pub(crate) root_page_id: PageId,
     pub(crate) root_subtrie_page_id: PageId,
     pub(crate) snapshot_id: SnapshotId,
-    transaction_metrics: RefCell<TransactionMetrics>,
+    pub(crate) transaction_metrics: RefCell<TransactionMetrics>,
 }
 
 impl Metadata {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 mod account;
 mod database;
 mod location;
+mod metrics;
 mod node;
 mod page;
 mod path;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,27 @@
+use metrics::Histogram;
+use metrics_derive::Metrics;
+
+#[derive(Metrics, Clone)]
+#[metrics(scope = "triedb")]
+pub struct DatabaseMetrics {
+    /// The number of pages read by a read-only transaction
+    #[metrics(describe = "The number of pages read by a read-only transaction")]
+    pub(crate) ro_transaction_pages_read: Histogram,
+    /// The number of pages written by a read-write transaction
+    #[metrics(describe = "The number of pages written by a read-write transaction")]
+    pub(crate) rw_transaction_pages_written: Histogram,
+    /// The number of pages read by a read-write transaction
+    #[metrics(describe = "The number of pages read by a read-write transaction")]
+    pub(crate) rw_transaction_pages_read: Histogram,
+    /// The number of pages allocated by a read-write transaction
+    #[metrics(describe = "The number of pages allocated by a read-write transaction")]
+    pub(crate) rw_transaction_pages_allocated: Histogram,
+}
+
+#[derive(Debug, Default, Clone)]
+pub(crate) struct TransactionMetrics {
+    pub(crate) pages_read: u32,
+    pub(crate) pages_written: u32,
+    pub(crate) pages_allocated: u32,
+    // TODO: add more metrics
+}

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -23,5 +23,6 @@ pub(crate) struct TransactionMetrics {
     pub(crate) pages_read: u32,
     pub(crate) pages_written: u32,
     pub(crate) pages_allocated: u32,
+    pub(crate) pages_reallocated: u32,
     // TODO: add more metrics
 }

--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -552,8 +552,7 @@ impl<P: PageManager> Inner<P> {
         metadata: &Metadata,
         page_id: PageId,
     ) -> Result<Page<'p, RW>, Error> {
-        let snapshot_id = metadata.snapshot_id;
-        let page = self.page_manager.get_mut(snapshot_id, page_id)?;
+        let page = self.page_manager.get_mut(metadata.snapshot_id, page_id)?;
         metadata.metrics_inc_pages_read();
         Ok(page)
     }
@@ -564,25 +563,16 @@ impl<P: PageManager> Inner<P> {
         metadata: &Metadata,
         page_id: PageId,
     ) -> Result<Page<'p, RO>, Error> {
-        let result = self
-            .page_manager
-            .get(metadata.snapshot_id, page_id)
-            .map_err(|e| e.into());
-        if let Ok(_) = result {
-            metadata.metrics_inc_pages_read();
-        }
-        result
+        let page = self.page_manager.get(metadata.snapshot_id, page_id)?;
+        metadata.metrics_inc_pages_read();
+        Ok(page)
     }
+
     // a wrapper around the page manager allocate that increments the pages allocated metric
     fn page_manager_allocate<'p>(&mut self, metadata: &Metadata) -> Result<Page<'p, RW>, Error> {
-        let result = self
-            .page_manager
-            .allocate(metadata.snapshot_id)
-            .map_err(|e| e.into());
-        if let Ok(_) = result {
-            metadata.metrics_inc_pages_allocated();
-        }
-        result
+        let page = self.page_manager.allocate(metadata.snapshot_id)?;
+        metadata.metrics_inc_pages_allocated();
+        Ok(page)
     }
 
     fn allocate_page<'p>(&mut self, metadata: &Metadata) -> Result<Page<'p, RW>, Error> {

--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -645,6 +645,7 @@ mod tests {
             snapshot_id: 1,
             root_page_id: 0,
             root_subtrie_page_id,
+            transaction_metrics: Default::default(),
         };
         let storage_engine = StorageEngine::new(manager, orphan_manager);
         (storage_engine, metadata)

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -10,6 +10,8 @@ use crate::{
     storage::{engine::StorageEngine, value::Value},
 };
 pub use manager::TransactionManager;
+use metrics::Counter;
+use metrics_derive::Metrics;
 use sealed::sealed;
 
 #[sealed]
@@ -34,6 +36,19 @@ pub struct Transaction<'tx, K: TransactionKind, P: PageManager> {
     database: &'tx Database<P>,
     lock: Option<RwLockReadGuard<'tx, StorageEngine<P>>>,
     _marker: std::marker::PhantomData<K>,
+    // todo: add metrics
+}
+
+// Metrics for a transaction.
+#[derive(Metrics)]
+#[metrics(scope = "triedb.transaction")]
+pub(crate) struct TransactionMetrics {
+    pub(crate) pages_read: Counter,
+    pub(crate) pages_written: Counter,
+    pub(crate) pages_allocated: Counter,
+    pub(crate) nodes_read: Counter,
+    pub(crate) nodes_written: Counter,
+    pub(crate) nodes_allocated: Counter,
 }
 
 impl<'tx, K: TransactionKind, P: PageManager> Transaction<'tx, K, P> {


### PR DESCRIPTION
New feature:
1. Add several metrics for ro/rw transaction
- For ro transaction: pages_read (total page read from mmap of one read API, e.g. read_account)
- For rw transaction: pages_read, pages_write, pages_allocated
2. Metrics are histogram