### PR TITLE
[WIP] perf: Replace use of Nibbles with copy-less Path array type

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -193,7 +193,7 @@ mod tests {
     use std::fs::File;
     use tempdir::TempDir;
 
-    use crate::{account::AccountVec, path::AddressPath};
+    use crate::{account::AccountVec, path::Path};
 
     use super::*;
 
@@ -207,32 +207,28 @@ mod tests {
 
         let account1 = AccountVec::new(U256::from(100), 1, B256::ZERO, B256::ZERO);
         let mut tx = db.begin_rw().unwrap();
-        tx.set_account(AddressPath::for_address(address), Some(account1.clone()))
+        tx.set_account(&Path::for_address(address), Some(account1.clone()))
             .unwrap();
 
         tx.commit().unwrap();
 
         let account2 = AccountVec::new(U256::from(123), 456, B256::ZERO, B256::ZERO);
         let mut tx = db.begin_rw().unwrap();
-        tx.set_account(AddressPath::for_address(address), Some(account2.clone()))
+        tx.set_account(&Path::for_address(address), Some(account2.clone()))
             .unwrap();
 
         let ro_tx = db.begin_ro().unwrap();
         tx.commit().unwrap();
 
         // The read transaction was created before the write was committed, so it should not see the changes.
-        let read_account = ro_tx
-            .get_account(AddressPath::for_address(address))
-            .unwrap();
+        let read_account = ro_tx.get_account(&Path::for_address(address)).unwrap();
 
         assert_eq!(account1, read_account.unwrap());
 
         // The writer transaction is committed, so the read transaction should see the changes.
         let ro_tx = db.begin_ro().unwrap();
 
-        let read_account = ro_tx
-            .get_account(AddressPath::for_address(address))
-            .unwrap();
+        let read_account = ro_tx.get_account(&Path::for_address(address)).unwrap();
 
         assert_eq!(account2, read_account.unwrap());
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,54 +1,245 @@
+use std::{
+    cmp::min,
+    fmt::Debug,
+    ops::{Deref, Index, Range},
+    slice::SliceIndex,
+};
+
 use alloy_primitives::{keccak256, Address, StorageKey};
 use alloy_trie::Nibbles;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct AddressPath {
-    path: Nibbles,
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
+pub struct Path {
+    nibbles: [u8; 128],
+    length: usize,
 }
 
-impl AddressPath {
-    pub fn new(path: Nibbles) -> Self {
-        assert_eq!(path.len(), 64, "Address path must be 64 nibbles long");
-
-        Self { path }
+impl Path {
+    #[inline]
+    pub fn new() -> Self {
+        Self {
+            nibbles: [0; 128],
+            length: 0,
+        }
     }
 
+    #[inline]
+    pub fn from_nibbles<T: AsRef<[u8]>>(nibbles: T) -> Self {
+        Self::from_nibbles_unchecked(nibbles)
+    }
+
+    #[inline]
+    pub fn new_address_path(path: &[u8]) -> Self {
+        assert_eq!(path.len(), 64, "Address path must be 64 nibbles long");
+        let mut nibbles = [0u8; 128];
+        nibbles[..64].copy_from_slice(path);
+        Self {
+            nibbles,
+            length: 64,
+        }
+    }
+
+    #[inline]
     pub fn for_address(address: Address) -> Self {
         let hash = keccak256(address);
-        Self {
-            path: Nibbles::unpack(hash),
-        }
+        Self::unpack(hash)
     }
-}
 
-impl From<AddressPath> for Nibbles {
-    fn from(path: AddressPath) -> Self {
-        path.path
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct StoragePath {
-    address: AddressPath,
-    slot: Nibbles,
-}
-
-impl StoragePath {
+    #[inline]
     pub fn for_address_and_slot(address: Address, slot: StorageKey) -> Self {
-        let address_nibbles = AddressPath::for_address(address);
+        let address_hash = keccak256(address);
         let slot_hash = keccak256(slot);
-        let slot_nibbles = Nibbles::unpack(slot_hash);
+        Self::unpack_two(address_hash, slot_hash)
+    }
+
+    #[inline]
+    pub fn get_slot_path(&self) -> Option<Nibbles> {
+        let slot_nibbles = self.nibbles.get(64..)?;
+        Some(Nibbles::from_nibbles(slot_nibbles))
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.length
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.length == 0
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &[u8] {
+        &self.nibbles[..self.length]
+    }
+
+    #[inline]
+    pub fn unpack<T: AsRef<[u8]>>(data: T) -> Self {
+        Self::unpack_(data.as_ref())
+    }
+
+    #[inline]
+    fn unpack_two<T: AsRef<[u8]>>(data1: T, data2: T) -> Self {
+        Self::unpack_two_(data1.as_ref(), data2.as_ref())
+    }
+
+    #[inline]
+    fn unpack_(data: &[u8]) -> Self {
+        let unpacked_len = data
+            .len()
+            .checked_mul(2)
+            .expect("trying to unpack usize::MAX / 2 bytes");
+        let mut path = [0u8; 128];
+        unsafe { Self::unpack_to_unchecked(data, path.as_mut_slice()) };
         Self {
-            address: address_nibbles,
-            slot: slot_nibbles,
+            nibbles: path,
+            length: unpacked_len,
         }
     }
 
-    pub fn full_path(&self) -> Nibbles {
-        self.address.path.join(&self.slot)
+    #[inline]
+    fn unpack_two_(data1: &[u8], data2: &[u8]) -> Self {
+        let unpacked_len = data1
+            .len()
+            .checked_add(data2.len())
+            .expect("trying to unpack usize::MAX / 2 bytes")
+            .checked_mul(2)
+            .expect("trying to unpack usize::MAX / 2 bytes");
+        let mut path = [0u8; 128];
+        unsafe {
+            Self::unpack_to_unchecked(data1, path.as_mut_slice());
+            Self::unpack_to_unchecked(
+                data2,
+                path.as_mut_slice().get_unchecked_mut(data1.len() * 2..),
+            );
+        };
+        Self {
+            nibbles: path,
+            length: unpacked_len,
+        }
     }
 
-    pub fn get_slot(&self) -> Nibbles {
-        self.slot.clone()
+    #[inline]
+    pub unsafe fn unpack_to_unchecked(data: &[u8], out: &mut [u8]) {
+        debug_assert!(out.len() >= data.len() * 2);
+        let ptr = out.as_mut_ptr().cast::<u8>();
+        for (i, &byte) in data.iter().enumerate() {
+            ptr.add(i * 2).write(byte >> 4);
+            ptr.add(i * 2 + 1).write(byte & 0x0f);
+        }
     }
+
+    #[inline]
+    pub fn from_nibbles_unchecked<T: AsRef<[u8]>>(nibbles: T) -> Self {
+        let mut path = [0u8; 128];
+        path[..nibbles.as_ref().len()].copy_from_slice(nibbles.as_ref());
+        Self {
+            nibbles: path,
+            length: nibbles.as_ref().len(),
+        }
+    }
+
+    #[inline]
+    pub fn common_prefix_length(&self, other: &[u8]) -> usize {
+        common_prefix_length(self, other)
+    }
+
+    #[inline]
+    pub fn slice<'a, I: Debug>(&'a self, range: I) -> PathRef<'a>
+    where
+        Self: Index<I, Output = [u8]>,
+    {
+        PathRef::from_nibbles(&self[range])
+    }
+
+    #[inline]
+    pub fn get<I>(&self, index: I) -> Option<&<I as SliceIndex<[u8]>>::Output>
+    where
+        I: SliceIndex<[u8]>,
+    {
+        self.nibbles[..self.length].get(index)
+    }
+}
+
+pub struct PathRef<'a> {
+    nibbles: &'a [u8],
+}
+
+impl<'a> PathRef<'a> {
+    pub fn from_nibbles(nibbles: &'a [u8]) -> Self {
+        debug_assert!(nibbles.len() <= 128);
+        Self { nibbles }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.nibbles.len()
+    }
+
+    #[inline]
+    pub fn as_path(&self) -> Path {
+        Path::from_nibbles_unchecked(self.nibbles)
+    }
+
+    #[inline]
+    pub fn common_prefix_length(&self, other: &[u8]) -> usize {
+        common_prefix_length(self.nibbles, other)
+    }
+
+    #[inline]
+    pub fn get<I>(&self, index: I) -> Option<&<I as SliceIndex<[u8]>>::Output>
+    where
+        I: SliceIndex<[u8]>,
+    {
+        self.nibbles.get(index)
+    }
+}
+
+impl<'a> AsRef<[u8]> for Path {
+    fn as_ref(&self) -> &[u8] {
+        self.as_slice()
+    }
+}
+
+impl Deref for Path {
+    type Target = [u8];
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+impl<'a> Deref for PathRef<'a> {
+    type Target = [u8];
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.nibbles
+    }
+}
+
+impl From<Path> for Nibbles {
+    fn from(path: Path) -> Self {
+        Nibbles::from_nibbles(path.as_slice())
+    }
+}
+
+impl<I: SliceIndex<[u8]>> Index<I> for Path {
+    type Output = I::Output;
+
+    fn index(&self, index: I) -> &Self::Output {
+        &self.as_slice()[index]
+    }
+}
+
+#[inline]
+pub fn common_prefix_length(a: &[u8], b: &[u8]) -> usize {
+    let len = core::cmp::min(a.len(), b.len());
+    let a = &a[..len];
+    let b = &b[..len];
+    for i in 0..len {
+        if a[i] != b[i] {
+            return i;
+        }
+    }
+    len
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -6,7 +6,7 @@ use crate::{
     account::Account,
     database::{Database, Metadata},
     page::PageManager,
-    path::AddressPath,
+    path::Path,
     storage::{engine::StorageEngine, value::Value},
 };
 use alloy_rlp::Encodable;
@@ -54,7 +54,7 @@ impl<'tx, K: TransactionKind, P: PageManager> Transaction<'tx, K, P> {
 
     pub fn get_account<A: Account + Value>(
         &'tx self,
-        address_path: AddressPath,
+        address_path: &Path,
     ) -> Result<Option<A>, ()> {
         let storage_engine = self.database.inner.storage_engine.read().unwrap();
         let account = storage_engine
@@ -71,7 +71,7 @@ impl<'tx, K: TransactionKind, P: PageManager> Transaction<'tx, K, P> {
 impl<P: PageManager> Transaction<'_, RW, P> {
     pub fn set_account<A: Account + Value + Encodable + Clone>(
         &mut self,
-        address_path: AddressPath,
+        address_path: &Path,
         account: Option<A>,
     ) -> Result<(), ()> {
         let storage_engine = self.database.inner.storage_engine.read().unwrap();


### PR DESCRIPTION
Use a 128 byte array type for paths, using one byte per nibble. This prevents the behavior of spilling over to the heap for long (storage) paths in the Nibbles package.

This also allows us to sub-slice into the same fixed path array during recursive traversal, instead of repeatedly copying data between Nibbles structs.

Realistically the performance gains from this will be greater whenever we implement custom RLP-encoding for Nodes/Accounts which does not require us to build Nibbles.

```
Benchmarking read_operations/random_reads/1000000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.8s, enable flat sampling, or reduce sample count to 50.
read_operations/random_reads/1000000
                        time:   [1.7486 ms 1.7578 ms 1.7680 ms]
                        thrpt:  [565.61 Kelem/s 568.89 Kelem/s 571.89 Kelem/s]
                 change:
                        time:   [-5.1169% -4.5678% -4.0257%] (p = 0.00 < 0.05)
                        thrpt:  [+4.1945% +4.7864% +5.3928%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

Benchmarking insert_operations/batch_inserts/1000000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.5s, or reduce sample count to 90.
insert_operations/batch_inserts/1000000
                        time:   [55.051 ms 57.725 ms 60.431 ms]
                        thrpt:  [16.548 Kelem/s 17.323 Kelem/s 18.165 Kelem/s]
                 change:
                        time:   [-8.9098% -2.9201% +3.6955%] (p = 0.36 > 0.05)
                        thrpt:  [-3.5638% +3.0080% +9.7813%]
                        No change in performance detected.

Benchmarking update_operations/batch_updates/1000000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.5s, or reduce sample count to 70.
update_operations/batch_updates/1000000
                        time:   [57.286 ms 59.851 ms 62.429 ms]
                        thrpt:  [16.018 Kelem/s 16.708 Kelem/s 17.456 Kelem/s]
                 change:
                        time:   [-7.9260% -2.1908% +3.6251%] (p = 0.47 > 0.05)
                        thrpt:  [-3.4983% +2.2399% +8.6083%]
                        No change in performance detected.

mixed_operations/mixed_workload/1000000
                        time:   [44.480 ms 44.913 ms 45.383 ms]
                        thrpt:  [22.035 Kelem/s 22.265 Kelem/s 22.482 Kelem/s]
                 change:
                        time:   [-22.376% -19.467% -16.385%] (p = 0.00 < 0.05)
                        thrpt:  [+19.596% +24.173% +28.826%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
```