### PR TITLE
perf: Directly serialize values to pages, no extra copies/allocs

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -160,17 +160,11 @@ impl<V: Value + Encodable> Node<V> {
 }
 
 impl<V: Value> Value for Node<V> {
-    fn to_bytes(&self) -> Vec<u8> {
+    fn size(&self) -> usize {
         match self {
             Self::StorageLeaf { prefix, value } => {
                 let prefix_length = prefix.len();
-                let value_bytes = value.to_bytes();
-                let mut data = vec![0; prefix_length + value_bytes.len() + 2];
-                data[0] = 0; // first byte 0 signifies a StorageLeaf
-                data[1] = prefix_length as u8;
-                data[2..2 + prefix_length].copy_from_slice(prefix.as_slice());
-                data[prefix_length + 2..].copy_from_slice(&value_bytes);
-                data
+                2 + prefix_length + value.size() // 2 bytes for type and prefix length
             }
             Self::AccountLeaf {
                 prefix,
@@ -178,42 +172,95 @@ impl<V: Value> Value for Node<V> {
                 storage_root,
             } => {
                 let prefix_length = prefix.len();
-                let value_bytes = value.to_bytes();
-                let mut data = vec![0; prefix_length + 37 + value_bytes.len() + 2];
-                data[0] = 1; // first byte 1 signifies a AccountLeaf
-                data[1] = prefix_length as u8;
-                data[2..2 + prefix_length].copy_from_slice(prefix.as_slice());
-                if let Some(storage) = storage_root {
-                    data[prefix_length + 2..prefix_length + 2 + 37]
-                        .copy_from_slice(&storage.to_bytes());
-                } else {
-                    data[prefix_length + 2..prefix_length + 2 + 37].copy_from_slice(&[0; 37]);
-                };
-
-                data[prefix_length + 2 + 37..].copy_from_slice(&value_bytes);
-                data
+                2 + prefix_length + 37 + value.size() // 2 bytes for type and prefix length, 37 for storage root
             }
             Self::Branch { prefix, children } => {
                 let prefix_length = prefix.len();
-                let mut data = vec![0; prefix_length + 4];
-                data[0] = 2; // first byte 2 signifies a Branch
-                data[1] = prefix_length as u8;
-                data[2..2 + prefix_length].copy_from_slice(prefix.as_slice());
+                2 + prefix_length + 2 + 16 * 37 // 2 bytes for type and prefix length, 2 for bitmask, 37 for each child pointer
+            }
+        }
+    }
+
+    fn serialize_into(&self, buf: &mut [u8]) -> value::Result<usize> {
+        match self {
+            Self::StorageLeaf { prefix, value } => {
+                let prefix_length = prefix.len();
+                let total_size = 2 + prefix_length + value.size();
+                if buf.len() < total_size {
+                    return Err(value::Error::InvalidEncoding);
+                }
+
+                buf[0] = 0; // StorageLeaf type
+                buf[1] = prefix_length as u8;
+                buf[2..2 + prefix_length].copy_from_slice(prefix.as_slice());
+                let bytes_written = value.serialize_into(&mut buf[2 + prefix_length..])?;
+
+                Ok(2 + prefix_length + bytes_written)
+            }
+            Self::AccountLeaf {
+                prefix,
+                value,
+                storage_root,
+            } => {
+                let prefix_length = prefix.len();
+                let total_size = 2 + prefix_length + 37 + value.size();
+                if buf.len() < total_size {
+                    return Err(value::Error::InvalidEncoding);
+                }
+
+                buf[0] = 1; // AccountLeaf type
+                buf[1] = prefix_length as u8;
+                buf[2..2 + prefix_length].copy_from_slice(prefix.as_slice());
+
+                let storage_offset = 2 + prefix_length;
+                if let Some(storage) = storage_root {
+                    // Serialize the pointer
+                    storage.serialize_into(&mut buf[storage_offset..storage_offset + 37])?;
+                } else {
+                    // Fill with zeros if no storage root
+                    buf[storage_offset..storage_offset + 37].fill(0);
+                }
+
+                let bytes_written = value.serialize_into(&mut buf[storage_offset + 37..])?;
+
+                Ok(storage_offset + 37 + bytes_written)
+            }
+            Self::Branch { prefix, children } => {
+                let prefix_length = prefix.len();
+                let mut total_size = 2 + prefix_length + 2; // Type, prefix length, bitmask
+                for child in children.iter().flatten() {
+                    total_size += 37; // Each pointer is 37 bytes
+                }
+
+                if buf.len() < total_size {
+                    return Err(value::Error::InvalidEncoding);
+                }
+
+                buf[0] = 2; // Branch type
+                buf[1] = prefix_length as u8;
+                buf[2..2 + prefix_length].copy_from_slice(prefix.as_slice());
+
+                // Calculate and store the children bitmask
                 let children_bitmask = children
                     .iter()
                     .enumerate()
                     .map(|(idx, child)| (child.is_some() as u16) << (15 - idx))
                     .sum::<u16>();
-                data[prefix_length + 2..prefix_length + 2 + 2]
+                buf[prefix_length + 2..prefix_length + 4]
                     .copy_from_slice(&children_bitmask.to_be_bytes());
+
+                // Store each child pointer
+                let mut offset = prefix_length + 4;
                 for child in children.iter() {
                     if let Some(child) = child {
-                        data.extend_from_slice(&child.to_bytes());
+                        child.serialize_into(&mut buf[offset..offset + 37])?;
                     } else {
-                        data.extend_from_slice(&[0; 37]);
+                        buf[offset..offset + 37].fill(0);
                     }
+                    offset += 37;
                 }
-                data
+
+                Ok(offset)
             }
         }
     }
@@ -349,24 +396,24 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_storage_leaf_node_to_bytes() {
+    fn test_storage_leaf_node_serialize() {
         let node = Node::new_storage_leaf(Nibbles::from_nibbles([0xa, 0xb]), vec![4, 5, 6]);
-        let bytes = node.to_bytes();
+        let bytes = node.serialize().unwrap();
         assert_eq!(bytes, hex!("00020a0b040506"));
 
         let node = Node::new_storage_leaf(Nibbles::from_nibbles([0xa, 0xb, 0xc]), vec![4, 5, 6, 7]);
-        let bytes = node.to_bytes();
+        let bytes = node.serialize().unwrap();
         assert_eq!(bytes, hex!("00030a0b0c04050607"));
 
         let node = Node::new_storage_leaf(Nibbles::new(), vec![0xf, 0xf, 0xf, 0xf]);
-        let bytes = node.to_bytes();
+        let bytes = node.serialize().unwrap();
         assert_eq!(bytes, hex!("00000f0f0f0f"));
     }
 
     #[test]
-    fn test_account_leaf_node_to_bytes() {
+    fn test_account_leaf_node_serialize() {
         let node = Node::new_account_leaf(Nibbles::from_nibbles([0xa, 0xb]), vec![4, 5, 6], None);
-        let bytes = node.to_bytes();
+        let bytes = node.serialize().unwrap();
         assert_eq!(bytes, hex!("01020a0b00000000000000000000000000000000000000000000000000000000000000000000000000040506"));
 
         let node = Node::new_account_leaf(
@@ -374,22 +421,22 @@ mod tests {
             vec![4, 5, 6, 7],
             None,
         );
-        let bytes = node.to_bytes();
+        let bytes = node.serialize().unwrap();
         assert_eq!(bytes, hex!("01030a0b0c0000000000000000000000000000000000000000000000000000000000000000000000000004050607"));
 
         let node = Node::new_account_leaf(Nibbles::new(), vec![0xf, 0xf, 0xf, 0xf], None);
-        let bytes = node.to_bytes();
+        let bytes = node.serialize().unwrap();
         assert_eq!(bytes, hex!("0100000000000000000000000000000000000000000000000000000000000000000000000000000f0f0f0f"));
     }
 
     #[test]
-    fn test_branch_node_to_bytes() {
+    fn test_branch_node_serialize() {
         let mut node: Node<Vec<u8>> = Node::new_branch(Nibbles::new());
         let hash1 = b256!("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef");
         let hash2 = b256!("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
         node.set_child(0, Pointer::new(42.into(), RlpNode::word_rlp(&hash1)));
         node.set_child(11, Pointer::new(11.into(), RlpNode::word_rlp(&hash2)));
-        let bytes = node.to_bytes();
+        let bytes = node.serialize().unwrap();
         // branch, no prefix
         let mut expected = Vec::from([2, 0]);
         // children bitmask (10000000 00010000)
@@ -412,7 +459,7 @@ mod tests {
         let hash2 = b256!("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
         node.set_child(2, Pointer::new(2.into(), RlpNode::word_rlp(&hash1)));
         node.set_child(3, Pointer::new(3.into(), RlpNode::word_rlp(&hash2)));
-        let bytes = node.to_bytes();
+        let bytes = node.serialize().unwrap();
         // branch, length, prefix
         let mut expected = Vec::from([2, 5, 10, 11, 12, 13, 14]);
         // children bitmask (00110000 00000000)
@@ -434,7 +481,7 @@ mod tests {
         let v2 = encode("hello world");
         node.set_child(1, Pointer::new(99999.into(), RlpNode::from_rlp(&v1)));
         node.set_child(2, Pointer::new(8675309.into(), RlpNode::from_rlp(&v2)));
-        let bytes = node.to_bytes();
+        let bytes = node.serialize().unwrap();
 
         // branch, length, prefix
         let mut expected = Vec::from([2, 2, 0, 0]);
@@ -661,7 +708,7 @@ mod tests {
     proptest! {
         #[test]
         fn fuzz_node_to_from_bytes(node: Node<AccountVec>) {
-            let bytes = node.clone().to_bytes();
+            let bytes = node.serialize().unwrap();
             let decoded = Node::from_bytes(&bytes).unwrap();
             assert_eq!(node, decoded);
         }

--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -763,7 +763,7 @@ impl<P: PageManager> StorageEngine<P> {
     ) -> Result<Pointer, Error> {
         // We are at an AccountLeaf and our storage just changed. Let's update our storage root.
         let value = node.value().expect("must be account leaf");
-        let account: AccountVec = AccountVec::from_bytes(value.to_bytes().as_slice())
+        let account: AccountVec = AccountVec::from_bytes(value.serialize().unwrap().as_slice())
             .expect("valid account vector encoding");
         let updated_account = AccountVec::new(
             account.balance(),


### PR DESCRIPTION
Changes the Value trait for more efficient writing to disk. Replaces `to_bytes` with `size` and `serialize_into`, which allows for data to be written directly to the page buffer without needing an intermediate allocation or copy. This shows somewhere around a 15% improvement for 1K batch benchmarks.

```
Benchmarking read_operations/random_reads/1000000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.0s, enable flat sampling, or reduce sample count to 50.
read_operations/random_reads/1000000
                        time:   [1.7884 ms 1.7964 ms 1.8065 ms]
                        thrpt:  [553.56 Kelem/s 556.66 Kelem/s 559.17 Kelem/s]
                 change:
                        time:   [-2.8088% -2.2301% -1.6298%] (p = 0.00 < 0.05)
                        thrpt:  [+1.6568% +2.2810% +2.8900%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe
read_operations/random_reads/3000000
                        time:   [1.9856 ms 1.9909 ms 1.9962 ms]
                        thrpt:  [500.96 Kelem/s 502.29 Kelem/s 503.63 Kelem/s]
                 change:
                        time:   [-1.4452% -0.9779% -0.5300%] (p = 0.00 < 0.05)
                        thrpt:  [+0.5328% +0.9875% +1.4664%]
                        Change within noise threshold.

insert_operations/batch_inserts/1000000
                        time:   [47.194 ms 47.671 ms 48.210 ms]
                        thrpt:  [20.743 Kelem/s 20.977 Kelem/s 21.189 Kelem/s]
                 change:
                        time:   [-24.493% -21.124% -17.489%] (p = 0.00 < 0.05)
                        thrpt:  [+21.196% +26.781% +32.438%]
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe
Benchmarking insert_operations/batch_inserts/3000000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.2s, or reduce sample count to 60.
insert_operations/batch_inserts/3000000
                        time:   [75.130 ms 78.473 ms 81.812 ms]
                        thrpt:  [12.223 Kelem/s 12.743 Kelem/s 13.310 Kelem/s]
                 change:
                        time:   [-1.9497% +4.5814% +11.578%] (p = 0.17 > 0.05)
                        thrpt:  [-10.376% -4.3807% +1.9885%]
                        No change in performance detected.

Benchmarking update_operations/batch_updates/1000000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.9s, or reduce sample count to 80.
update_operations/batch_updates/1000000
                        time:   [53.427 ms 55.976 ms 58.509 ms]
                        thrpt:  [17.091 Kelem/s 17.865 Kelem/s 18.717 Kelem/s]
                 change:
                        time:   [-12.345% -6.4739% -1.0271%] (p = 0.04 < 0.05)
                        thrpt:  [+1.0377% +6.9220% +14.084%]
                        Performance has improved.
Benchmarking update_operations/batch_updates/3000000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.6s, or reduce sample count to 50.
update_operations/batch_updates/3000000
                        time:   [78.914 ms 82.468 ms 86.051 ms]
                        thrpt:  [11.621 Kelem/s 12.126 Kelem/s 12.672 Kelem/s]
                 change:
                        time:   [-3.7372% +2.7086% +9.5811%] (p = 0.42 > 0.05)
                        thrpt:  [-8.7434% -2.6372% +3.8823%]
                        No change in performance detected.

mixed_operations/mixed_workload/1000000
                        time:   [37.786 ms 38.165 ms 38.573 ms]
                        thrpt:  [25.925 Kelem/s 26.202 Kelem/s 26.465 Kelem/s]
                 change:
                        time:   [-16.253% -15.026% -13.774%] (p = 0.00 < 0.05)
                        thrpt:  [+15.974% +17.683% +19.407%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
Benchmarking mixed_operations/mixed_workload/3000000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.1s, or reduce sample count to 70.
mixed_operations/mixed_workload/3000000
                        time:   [64.606 ms 67.367 ms 70.197 ms]
                        thrpt:  [14.246 Kelem/s 14.844 Kelem/s 15.478 Kelem/s]
                 change:
                        time:   [-17.272% -12.415% -7.4973%] (p = 0.00 < 0.05)
                        thrpt:  [+8.1050% +14.174% +20.879%]
                        Performance has improved.
```