### PR TITLE
perf: Remove Redundant RLP Encoding

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -378,24 +378,16 @@ impl<V: Value + Encodable> Encodable for Node<V> {
     fn length(&self) -> usize {
         match self {
             Self::StorageLeaf { prefix, value } => {
-                let value_rlp = encode(value);
-                LeafNodeRef {
-                    key: prefix,
-                    value: &value_rlp,
-                }
-                .length()
+                // this just has to be an estimate for `Vec::with_capacity`
+                prefix.len() + value.size() + 10 // 10 is just a buffer
             }
             Self::AccountLeaf {
                 prefix,
                 value,
                 storage_root,
             } => {
-                let value_rlp = encode(value);
-                LeafNodeRef {
-                    key: prefix,
-                    value: &value_rlp,
-                }
-                .length()
+                // this just has to be an estimate for `Vec::with_capacity`
+                prefix.len() + value.size() + 10 // 10 is just a buffer
             }
             Self::Branch { prefix, children } => {
                 if prefix.is_empty() {
@@ -416,7 +408,9 @@ impl<V: Value + Encodable> Encodable for Node<V> {
                 } else {
                     ExtensionNodeRef {
                         key: prefix,
-                        // hack: we know that
+                        // hack: we know that a branch node will always be a
+                        // RlpNode hash. since we only need the length, we use
+                        // a dummy zero value here.
                         child: &RlpNode::word_rlp(&B256::ZERO),
                     }
                     .length()


### PR DESCRIPTION
The generic `encode` function provided by alloy_rlp ends up encoding our `Node` twice.
This is because the function calls [value.length()](https://github.com/alloy-rs/rlp/blob/main/crates/rlp/src/encode.rs#L296) which if not implemented in the Encodable interface, results in the generic implementation encoding the value to [get the length](https://github.com/alloy-rs/rlp/blob/main/crates/rlp/src/encode.rs#L25-L28), and then calling `encode` again.

This PR implements the `length` function to avoid double encoding.

<img width="974" alt="Screenshot 2025-02-28 at 6 40 36 PM" src="https://github.com/user-attachments/assets/a0b86146-aadf-4113-9851-d0baa3799eaf" />
