### PR TITLE
refactor: Merge Account/Storage directly into Node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2107,6 +2107,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
+ "arrayvec",
  "criterion",
  "log",
  "memmap2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 alloy-primitives = { version = "0.8.21", features = ["arbitrary", "rand"] }
 alloy-rlp = "0.3.11"
 alloy-trie = { version = "0.7.6", features=["arbitrary", "ethereum"]}
+arrayvec = "0.7.6"
 log = "0.4.25"
 memmap2 = "0.9.5"
 proptest = "1.6.0"

--- a/src/account.rs
+++ b/src/account.rs
@@ -1,84 +1,16 @@
 use alloy_primitives::{B256, U256};
-use alloy_rlp::{BufMut, Encodable, RlpEncodable};
-use proptest::{
-    arbitrary::{Arbitrary, Mapped},
-    prelude::{any, Strategy},
-};
 use proptest_derive::Arbitrary;
 use std::fmt::Debug;
 
-use crate::storage::value::{self, Value, ValueRef};
-
-pub trait Account {
-    fn nonce(&self) -> u64;
-    fn balance(&self) -> U256;
-    fn code_hash(&self) -> B256;
-    fn storage_root(&self) -> B256;
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AccountVec {
-    data: Vec<u8>,
-}
-
-impl AccountVec {
-    pub fn new(balance: U256, nonce: u64, code_hash: B256, storage_root: B256) -> Self {
-        let mut data = vec![0; 104];
-        data[0..32].copy_from_slice(&balance.to_be_bytes::<32>());
-        data[32..40].copy_from_slice(&nonce.to_be_bytes());
-        data[40..72].copy_from_slice(code_hash.as_slice());
-        data[72..104].copy_from_slice(storage_root.as_slice());
-        Self { data }
-    }
-}
-
-impl Account for AccountVec {
-    fn balance(&self) -> U256 {
-        U256::from_be_slice(&self.data[0..32])
-    }
-
-    fn nonce(&self) -> u64 {
-        u64::from_be_bytes(self.data[32..40].try_into().expect("nonce is 8 bytes"))
-    }
-
-    fn code_hash(&self) -> B256 {
-        B256::from_slice(&self.data[40..72])
-    }
-
-    fn storage_root(&self) -> B256 {
-        B256::from_slice(&self.data[72..104])
-    }
-}
-
-impl Value for AccountVec {
-    fn size(&self) -> usize {
-        self.data.len()
-    }
-
-    fn serialize_into(&self, buf: &mut [u8]) -> value::Result<usize> {
-        if buf.len() < self.data.len() {
-            return Err(value::Error::InvalidEncoding);
-        }
-        buf[..self.data.len()].copy_from_slice(&self.data);
-        Ok(self.data.len())
-    }
-
-    fn from_bytes(bytes: &[u8]) -> value::Result<Self> {
-        Ok(Self {
-            data: bytes.to_vec(),
-        })
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, Arbitrary)]
-pub struct RlpAccount {
+#[derive(Debug, Clone, PartialEq, Eq, Arbitrary)]
+pub struct Account {
     pub nonce: u64,
     pub balance: U256,
     pub storage_root: B256,
     pub code_hash: B256,
 }
 
-impl RlpAccount {
+impl Account {
     pub fn new(nonce: u64, balance: U256, storage_root: B256, code_hash: B256) -> Self {
         Self {
             nonce,
@@ -89,165 +21,20 @@ impl RlpAccount {
     }
 }
 
-impl Account for RlpAccount {
-    #[inline]
-    fn nonce(&self) -> u64 {
-        self.nonce
-    }
-
-    #[inline]
-    fn balance(&self) -> U256 {
-        self.balance
-    }
-
-    #[inline]
-    fn code_hash(&self) -> B256 {
-        self.code_hash
-    }
-
-    #[inline]
-    fn storage_root(&self) -> B256 {
-        self.storage_root
-    }
-}
-
-impl Value for RlpAccount {
-    #[inline]
-    fn size(&self) -> usize {
-        104
-    }
-
-    fn serialize_into(&self, buf: &mut [u8]) -> value::Result<usize> {
-        if buf.len() < self.size() {
-            return Err(value::Error::InvalidEncoding);
-        }
-        buf[..32].copy_from_slice(self.balance.as_le_slice());
-        buf[32..40].copy_from_slice(&self.nonce.to_le_bytes());
-        buf[40..72].copy_from_slice(self.storage_root.as_slice());
-        buf[72..104].copy_from_slice(self.code_hash.as_slice());
-        Ok(self.size())
-    }
-
-    fn from_bytes(bytes: &[u8]) -> value::Result<Self> {
-        if bytes.len() != 104 {
-            return Err(value::Error::InvalidEncoding);
-        }
-        Ok(Self {
-            nonce: u64::from_be_bytes(bytes[0..8].try_into().expect("nonce is 8 bytes")),
-            balance: U256::from_be_slice(&bytes[8..40]),
-            storage_root: B256::from_slice(&bytes[40..72]),
-            code_hash: B256::from_slice(&bytes[72..104]),
-        })
-    }
-}
-
-impl Encodable for AccountVec {
-    fn encode(&self, out: &mut dyn BufMut) {
-        let rlp_account = RlpAccount {
-            nonce: self.nonce(),
-            balance: self.balance(),
-            storage_root: self.storage_root(),
-            code_hash: self.code_hash(),
-        };
-        rlp_account.encode(out);
-    }
-}
-
-impl Arbitrary for AccountVec {
-    type Parameters = ();
-    type Strategy = Mapped<(U256, u64, B256, B256), AccountVec>;
-    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
-        any::<(U256, u64, B256, B256)>().prop_map(
-            move |(balance, nonce, code_hash, storage_root)| {
-                AccountVec::new(balance, nonce, code_hash, storage_root)
-            },
-        )
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AccountSlice<'a> {
-    data: &'a [u8],
-}
-
-impl<'a> AccountSlice<'a> {
-    pub fn new(
-        balance: U256,
-        nonce: u64,
-        code_hash: B256,
-        storage_root: B256,
-        data: &'a mut [u8],
-    ) -> Self {
-        data[0..32].copy_from_slice(&balance.to_be_bytes::<32>());
-        data[32..40].copy_from_slice(&nonce.to_be_bytes());
-        data[40..72].copy_from_slice(code_hash.as_slice());
-        data[72..104].copy_from_slice(storage_root.as_slice());
-        Self { data }
-    }
-}
-
-impl Account for AccountSlice<'_> {
-    fn balance(&self) -> U256 {
-        U256::from_be_slice(&self.data[0..32])
-    }
-
-    fn nonce(&self) -> u64 {
-        u64::from_be_bytes(self.data[32..40].try_into().expect("nonce is 8 bytes"))
-    }
-
-    fn code_hash(&self) -> B256 {
-        B256::from_slice(&self.data[40..72])
-    }
-
-    fn storage_root(&self) -> B256 {
-        B256::from_slice(&self.data[72..104])
-    }
-}
-
-impl<'a> ValueRef<'a> for AccountSlice<'a> {
-    type Owned = AccountVec;
-
-    fn to_bytes(self) -> &'a [u8] {
-        self.data
-    }
-
-    fn from_bytes(bytes: &'a [u8]) -> value::Result<Self> {
-        Ok(Self { data: bytes })
-    }
-
-    fn to_owned(self) -> Self::Owned {
-        AccountVec {
-            data: self.data.to_vec(),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+
     use proptest::prelude::*;
 
     proptest! {
         #[test]
         fn fuzz_account_fields(balance: U256, nonce: u64, code_hash: B256, storage_root: B256) {
-            let account = AccountVec::new(balance, nonce, code_hash, storage_root);
-            assert_eq!(account.balance(), balance);
-            assert_eq!(account.nonce(), nonce);
-            assert_eq!(account.code_hash(), code_hash);
-            assert_eq!(account.storage_root(), storage_root);
-        }
-
-        #[test]
-        fn fuzz_account_to_from_bytes(account: AccountVec) {
-            let bytes = account.serialize().unwrap();
-            let decoded = AccountVec::from_bytes(&bytes).unwrap();
-            assert_eq!(account, decoded);
-        }
-
-        #[test]
-        fn fuzz_account_rlp_encode(account: AccountVec) {
-            let mut buf = vec![];
-            account.encode(&mut buf);
+            let account = Account::new(nonce, balance, storage_root, code_hash);
+            assert_eq!(account.nonce, nonce);
+            assert_eq!(account.balance, balance);
+            assert_eq!(account.storage_root, storage_root);
+            assert_eq!(account.code_hash, code_hash);
         }
     }
 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -240,7 +240,7 @@ mod tests {
     use std::fs::File;
     use tempdir::TempDir;
 
-    use crate::{account::RlpAccount, path::AddressPath};
+    use crate::{account::Account, path::AddressPath};
 
     use super::*;
 
@@ -252,14 +252,14 @@ mod tests {
 
         let address = address!("0xd8da6bf26964af9d7eed9e03e53415d37aa96045");
 
-        let account1 = RlpAccount::new(1, U256::from(100), EMPTY_ROOT_HASH, KECCAK_EMPTY);
+        let account1 = Account::new(1, U256::from(100), EMPTY_ROOT_HASH, KECCAK_EMPTY);
         let mut tx = db.begin_rw().unwrap();
         tx.set_account(AddressPath::for_address(address), Some(account1.clone()))
             .unwrap();
 
         tx.commit().unwrap();
 
-        let account2 = RlpAccount::new(456, U256::from(123), EMPTY_ROOT_HASH, KECCAK_EMPTY);
+        let account2 = Account::new(456, U256::from(123), EMPTY_ROOT_HASH, KECCAK_EMPTY);
         let mut tx = db.begin_rw().unwrap();
         tx.set_account(AddressPath::for_address(address), Some(account2.clone()))
             .unwrap();

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -59,11 +59,12 @@ impl Value for Pointer {
         let first_rlp_byte = arr[4];
         // Because the RLP string must be 1-33 bytes, we can safely use the first byte to determine the length.
         // If the first byte is less than 0x80, then this byte is the actual encoded value.
-        // Otherwise, the length is first_rlp_byte - 0x80.
+        // Otherwise, the length is first_rlp_byte - 0x80, and the remaining bytes are the encoded U256 value.
         let rlp = if first_rlp_byte < 0x80 {
             RlpNode::from_raw(&[first_rlp_byte]).unwrap()
         } else if first_rlp_byte <= 0xa0 {
             let rlp_len = first_rlp_byte - 0x80;
+
             RlpNode::from_raw(&arr[4..5 + rlp_len as usize]).unwrap()
         } else {
             return Err(value::Error::InvalidEncoding);

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -3,7 +3,7 @@ mod manager;
 use std::{fmt::Debug, sync::RwLockReadGuard};
 
 use crate::{
-    account::RlpAccount,
+    account::Account,
     database::{Database, TransactionContext},
     page::PageManager,
     path::{AddressPath, StoragePath},
@@ -52,7 +52,7 @@ impl<'tx, K: TransactionKind, P: PageManager> Transaction<'tx, K, P> {
         }
     }
 
-    pub fn get_account(&'tx self, address_path: AddressPath) -> Result<Option<RlpAccount>, ()> {
+    pub fn get_account(&'tx self, address_path: AddressPath) -> Result<Option<Account>, ()> {
         let storage_engine = self.database.inner.storage_engine.read().unwrap();
         let account = storage_engine
             .get_account(&self.context, address_path)
@@ -76,7 +76,7 @@ impl<P: PageManager> Transaction<'_, RW, P> {
     pub fn set_account(
         &mut self,
         address_path: AddressPath,
-        account: Option<RlpAccount>,
+        account: Option<Account>,
     ) -> Result<(), ()> {
         let storage_engine = self.database.inner.storage_engine.read().unwrap();
         storage_engine


### PR DESCRIPTION
This change updates the `Node` type to directly embed its value instead of relying on generics. In addition to simplifying some of the code, this primarily improves storage utilization by deduplicating the Account's storage root hash with the pointer to the root node.

In order to avoid unnecessary heap allocations, this also uses a simpler `Account` struct in place of `AccountVec`.

The `AccountLeaf` also directly embeds RLP-encoded numeric fields for `nonce` and `balance`, which allows for compact encoding (single byte for tiny values), while also deduplicating work related to RLP encoding as part of hash calculation. Storage Root and Code Hash are only serialized when not the default value, saving 64 bytes in most cases (EOAs).

This should reduce the space requirements by a minimum of 32 bytes per Account with the current uncompressed on-disk format.