### PR TITLE
feat: Pack 2 path nibbles per byte in serialization

### DIFF
--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -2806,8 +2806,8 @@ mod tests {
         storage_engine.commit(&context).unwrap();
 
         // assert we can get the child account we just added:
-        let child_1_nibbles = Nibbles::from_nibbles(child_1_full_path.clone());
-        let child_2_nibbles = Nibbles::from_nibbles(child_2_full_path.clone());
+        let child_1_nibbles = Nibbles::from_nibbles(child_1_full_path);
+        let child_2_nibbles = Nibbles::from_nibbles(child_2_full_path);
         let read_account1 = storage_engine
             .get_account::<AccountVec>(&context, AddressPath::new(child_1_nibbles.clone()))
             .unwrap();
@@ -2818,7 +2818,7 @@ mod tests {
         assert_eq!(read_account2, Some(test_account.clone()));
 
         // WHEN: child 1 is deleted
-        let child_1_path = Nibbles::from_nibbles(child_1_full_path.clone());
+        let child_1_path = Nibbles::from_nibbles(child_1_full_path);
         storage_engine
             .set_account::<AccountVec>(&mut context, AddressPath::new(child_1_path), None)
             .unwrap();
@@ -2913,8 +2913,8 @@ mod tests {
         storage_engine.commit(&context).unwrap();
 
         // assert we can get the children accounts we just added:
-        let child_1_nibbles = Nibbles::from_nibbles(child_1_full_path.clone());
-        let child_2_nibbles = Nibbles::from_nibbles(child_2_full_path.clone());
+        let child_1_nibbles = Nibbles::from_nibbles(child_1_full_path);
+        let child_2_nibbles = Nibbles::from_nibbles(child_2_full_path);
         let read_account1 = storage_engine
             .get_account::<AccountVec>(&context, AddressPath::new(child_1_nibbles.clone()))
             .unwrap();


### PR DESCRIPTION
Updates path serialization format to include 2 nibbles per byte, instead of only 1.

This now serializes the path using the following scheme:
`[num_nibbles, (n0, n1), (n2, ...)]` instead of `[num_nibbles, (0, n0), (0, n1), (0, n2), ...]`

In the case of an odd number of nibbles, an extra `0` is serialized at the end to fill out the last byte.

This is estimated to save just under 32 bytes per Account and Storage Slot, spread out across all nodes on the path to the value.