### PR TITLE
test: Add storage to real world state root test

### DIFF
--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -1490,13 +1490,71 @@ mod tests {
             .unwrap();
         assert_metrics(&context, 2, 1, 0, 0);
         storage_engine
-            .set_account(&mut context, path3, Some(account3.clone()))
+            .set_account(&mut context, path3.clone(), Some(account3.clone()))
             .unwrap();
         assert_metrics(&context, 3, 1, 0, 0);
 
         assert_eq!(
             context.metadata.state_root,
             b256!("0x6f78ee01791dd8a62b4e2e86fae3d7957df9fa7f7a717ae537f90bb0c79df296")
+        );
+
+        let account1_storage = [
+            (B256::with_last_byte(0x0c), U256::from(0x0c)),
+            (
+                b256!("0x000000000000000000000000000000000000000000000000000000000000200b"),
+                b256!("0x6c31fc15422ebad28aaf9089c306702f67540b53c7eea8b7d2941044b027100f").into(),
+            ),
+        ];
+
+        let account2_storage = vec![
+            (B256::with_last_byte(0x00), U256::from(0x01)),
+            (
+                B256::with_last_byte(0x01),
+                b256!("0x6c31fc15422ebad28aaf9089c306702f67540b53c7eea8b7d2941044b027100f").into(),
+            ),
+            (B256::with_last_byte(0x02), U256::from(0x20)),
+            (
+                B256::with_last_byte(0x03),
+                b256!("0x6c31fc15422ebad28aaf9089c306702f67540b53c7eea8b7d2941044b027100f").into(),
+            ),
+        ];
+
+        let account3_updated = AccountVec::new(
+            U256::from(0x3635c9adc5de938d5cu128),
+            1,
+            KECCAK_EMPTY,
+            EMPTY_ROOT_HASH,
+        );
+
+        account1_storage.iter().for_each(|(key, value)| {
+            storage_engine
+                .set_storage(
+                    &mut context,
+                    StoragePath::for_address_and_slot(address1, *key),
+                    Some(*value),
+                )
+                .unwrap();
+        });
+
+        account2_storage.iter().for_each(|(key, value)| {
+            storage_engine
+                .set_storage(
+                    &mut context,
+                    StoragePath::for_address_and_slot(address2, *key),
+                    Some(*value),
+                )
+                .unwrap();
+        });
+
+        storage_engine
+            .set_account(&mut context, path3, Some(account3_updated.clone()))
+            .unwrap();
+        assert_metrics(&context, 10, 1, 0, 0);
+
+        assert_eq!(
+            context.metadata.state_root,
+            b256!("0xf869dcb9ef8893f6b30bf495847fd99166aaf790ed962c468d11a826996ab2d2")
         );
     }
 


### PR DESCRIPTION
Add storage / updated account values to `test_simple_trie_state_root_2` to test the post-state in addition to the pre-state from following `ethereum/tests` fixture:

```json
"tests/cancun/eip4788_beacon_root/test_beacon_root_contract.py::test_beacon_root_contract_timestamps[fork_Cancun-blockchain_test_engine-empty_system_address-auto_access_list_False-timestamp_12-valid_input_True]": {
        "network": "Cancun",
        "genesisBlockHeader": {
            "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
            "uncleHash": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
            "coinbase": "0x0000000000000000000000000000000000000000",
            "stateRoot": "0x6f78ee01791dd8a62b4e2e86fae3d7957df9fa7f7a717ae537f90bb0c79df296",
            "transactionsTrie": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
            "receiptTrie": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
            "bloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
            "difficulty": "0x00",
            "number": "0x00",
            "gasLimit": "0x016345785d8a0000",
            "gasUsed": "0x00",
            "timestamp": "0x00",
            "extraData": "0x00",
            "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
            "nonce": "0x0000000000000000",
            "baseFeePerGas": "0x07",
            "withdrawalsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
            "blobGasUsed": "0x00",
            "excessBlobGas": "0x00",
            "parentBeaconBlockRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
            "hash": "0x338e5f2a5ba99968a22fc072966f5068b03d94c3adc6dbab3e3753aba34ad69c"
        },
        "pre": {
            "0x000f3df6d732807ef1319fb7b8bb8522d0beac02": {
                "nonce": "0x01",
                "balance": "0x00",
                "code": "0x3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500",
                "storage": {}
            },
            "0x0000000000000000000000000000000000001000": {
                "nonce": "0x01",
                "balance": "0x010000000000",
                "code": "0x366000602037602060003660206000720f3df6d732807ef1319fb7b8bb8522d0beac02620186a0f16000556000516001553d6002553d600060003e600051600355",
                "storage": {}
            },
            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
                "nonce": "0x00",
                "balance": "0x3635c9adc5dea00000",
                "code": "0x",
                "storage": {}
            }
        },
        "postState": {
            "0x000f3df6d732807ef1319fb7b8bb8522d0beac02": {
                "nonce": "0x01",
                "balance": "0x00",
                "code": "0x3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500",
                "storage": {
                    "0x0c": "0x0c",
                    "0x200b": "0x6c31fc15422ebad28aaf9089c306702f67540b53c7eea8b7d2941044b027100f"
                }
            },
            "0x0000000000000000000000000000000000001000": {
                "nonce": "0x01",
                "balance": "0x010000000000",
                "code": "0x366000602037602060003660206000720f3df6d732807ef1319fb7b8bb8522d0beac02620186a0f16000556000516001553d6002553d600060003e600051600355",
                "storage": {
                    "0x00": "0x01",
                    "0x01": "0x6c31fc15422ebad28aaf9089c306702f67540b53c7eea8b7d2941044b027100f",
                    "0x02": "0x20",
                    "0x03": "0x6c31fc15422ebad28aaf9089c306702f67540b53c7eea8b7d2941044b027100f"
                }
            },
            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
                "nonce": "0x01",
                "balance": "0x3635c9adc5de938d5c",
                "code": "0x",
                "storage": {}
            }
        },
        "lastblockhash": "0x9858e6631a669b874a29a96bbc9d1756b23d281db64b7bd1bda8bc232967446f",
        "config": {
            "network": "Cancun",
            "chainid": "0x01",
            "blobSchedule": {
                "Cancun": {
                    "target": "0x03",
                    "max": "0x06",
                    "baseFeeUpdateFraction": "0x32f0ed"
                }
            }
        },
        "engineNewPayloads": [
            {
                "params": [
                    {
                        "parentHash": "0x338e5f2a5ba99968a22fc072966f5068b03d94c3adc6dbab3e3753aba34ad69c",
                        "feeRecipient": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
                        "stateRoot": "0xf869dcb9ef8893f6b30bf495847fd99166aaf790ed962c468d11a826996ab2d2",
                        "receiptsRoot": "0x56c22a6b2c9ca708dca598477f7c7391409272310505c9844e52aac13bf08af0",
                        "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
                        "blockNumber": "0x1",
                        "gasLimit": "0x16345785d8a0000",
                        "gasUsed": "0x1c73c",
                        "timestamp": "0xc",
                        "extraData": "0x",
                        "prevRandao": "0x0000000000000000000000000000000000000000000000000000000000000000",
                        "baseFeePerGas": "0x7",
                        "blobGasUsed": "0x0",
                        "excessBlobGas": "0x0",
                        "blockHash": "0x9858e6631a669b874a29a96bbc9d1756b23d281db64b7bd1bda8bc232967446f",
                        "transactions": [
                            "0x02f88301808007830f424094000000000000000000000000000000000000100080a0000000000000000000000000000000000000000000000000000000000000000cc080a00250e37fb1094dca850d5e9930a67cfcbdfb10dd4e93d576c1add47ebcaa9087a077e2484f633730a17870768524826e03dbb3a1856b5b07b850631453167b42c5"
                        ],
                        "withdrawals": []
                    },
                    [],
                    "0x6c31fc15422ebad28aaf9089c306702f67540b53c7eea8b7d2941044b027100f"
                ],
                "newPayloadVersion": "3",
                "forkchoiceUpdatedVersion": "3"
            }
        ],
        "_info": {
            "hash": "0x67661651d2541fc8ed14d0371f17dd69aace784eab35ef0ad475a48aa48c9d2d",
            "comment": "`execution-spec-tests` generated test",
            "filling-transition-tool": "ethereum-spec-evm-resolver 0.0.5",
            "description": "Test function documentation:\n\n    Tests the beacon root contract call across for various valid and invalid timestamps.\n\n    The expected result is that the contract call will return the correct\n    `parent_beacon_block_root` for a valid input timestamp and return the zero'd 32 bytes value\n    for an invalid input timestamp.",
            "url": "https://github.com/ethereum/execution-spec-tests/tree/v4.0.0/tests/cancun/eip4788_beacon_root/test_beacon_root_contract.py#L95",
            "fixture_format": "blockchain_test_engine",
            "reference-spec": "https://github.com/ethereum/EIPs/blob/master/EIPS/eip-4788.md",
            "reference-spec-version": "e7608fe8ac8a60934ca874f5aab7d5c1f4ff7782",
            "eels-resolution": {
                "git-url": "https://github.com/ethereum/execution-specs.git",
                "branch": "master",
                "commit": "78fb726158c69d8fa164e28f195fabf6ab59b915"
            }
        }
    }
```