### PR TITLE
bug: Fix Extension Node Single Child Prefix

### DIFF
--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -604,6 +604,7 @@ impl<P: PageManager> StorageEngine<P> {
                     };
 
                 let mut new_nibbles = Nibbles::new();
+                new_nibbles = new_nibbles.join(node.prefix());
                 new_nibbles.push(only_child_index);
                 new_nibbles = new_nibbles.join(only_child_node.prefix());
                 only_child_node.set_prefix(new_nibbles);


### PR DESCRIPTION
When deleting a node, if the the single child branch node is actually an extension node (has a prefix), we need to add this prefix to the new child when we delete the branch node. 