### PR TITLE
bug: Fix VecDeque Rotate Length

### DIFF
--- a/src/page/root.rs
+++ b/src/page/root.rs
@@ -651,4 +651,32 @@ mod tests {
         let orphan_page_ids = root_page.get_orphaned_page_ids(&page_manager).unwrap();
         assert_eq!(orphan_page_ids.len(), 0)
     }
+
+    #[test]
+    fn test_vecdeque_rotate_orphan_page_ids() {
+        // GIVEN: a root page with orphan ids
+        let mut page_manager = MmapPageManager::new_anon(20, 0).unwrap();
+        let page = page_manager.allocate(42).unwrap();
+        let mut root_page = RootPage::new(page, B256::default(), 0);
+        let my_orphan_page_ids: &[PageId] = &[2, 3, 4, 5, 6, 7, 8, 9, 10];
+        root_page
+            .add_orphaned_page_ids(my_orphan_page_ids, 0, &mut page_manager)
+            .unwrap();
+
+        // WHEN: more than half of the list is "given out"
+        let num_orphan_slots_used = 6;
+        let orphan_page_ids_left = &[8, 9, 10];
+        root_page
+            .add_orphaned_page_ids(
+                orphan_page_ids_left,
+                num_orphan_slots_used,
+                &mut page_manager,
+            )
+            .unwrap();
+
+        // THEN: vecdeque rotate_right should not panic given that the num_orphan_slots_used is
+        // greater than the new list to add.
+        let orphan_page_ids = root_page.get_orphaned_page_ids(&page_manager).unwrap();
+        assert_eq!(orphan_page_ids_left.to_vec(), orphan_page_ids);
+    }
 }


### PR DESCRIPTION
VecDeque has an assertion that the rotate_right isn't longer than the length of the actually list. For example, if we have a list of size 3: [1, 2, 3] attempting to rotate_right by 5 would panic. Instead we need to rotate it by (5 % 3).

This can happen if we give away more than half our orphan pages. For example, let's say we start off with 100 orphan pages and we give away 60. This means the orphan page list has 40 elements and we will attempt to right shift it by 60 which will panic (since 60 > 40)