### PR TITLE
bug: Fix Pointers Still Using Orphaned Pages on Delete

### DIFF
--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -832,8 +832,8 @@ impl<P: PageManager> StorageEngine<P> {
                     // 3. and add new cell pointer for the new leaf node (3 bytes)
                     // when adding the new child, split the page.
                     // FIXME: is it safe to split the page here if we've already modified the page?
-                    if slotted_page.num_free_bytes()
-                        < node_size_incr + new_node.size() + CELL_POINTER_SIZE
+                    if slotted_page.num_free_bytes() <
+                        node_size_incr + new_node.size() + CELL_POINTER_SIZE
                     {
                         self.split_page(context, slotted_page)?;
                         return Err(Error::PageSplit);


### PR DESCRIPTION
These PR solves 2 problems:

**Problem 1:**
If a value is deleted that doesn't exist, it throws an error which can cause original pages to be orphaned and cloned pages to not be recorded (since we are bubbling up an error and not setting node pointers).
Consider the following example:
1. We attempt to delete a value and are traversing down the trie
2. We call `get_mut_clone` for every page along the path. This immediately orphans the current page and creates a clone
3. We find that the value to delete doesn't exist and we throw an an error
4. We stop recursing and return, bubbling this error back up our recursion
5. Because it's an error, we do not update any node pointers
6. Our original pages are orphaned and no pointers were updated to the cloned pages
7. After we commit and attempt to get the value using another RW transaction, the original page (which is now an unlocked orphan page) may be overwritten and the path to the value is no longer possible

**Problem 2:**
Given that we are writing all changes in a single traversal, it is possible that we attempt to delete a value _twice_ if a page split occurs during our single traversal write.
Consider the following example:
1. Our changes are [delete, insert, insert, insert, insert] all with very similar paths so they all affect the same Page (e.g writing storage)
2. We successfully delete the element we want from the Page
3. We insert 2 of the next values
4. On the third insert (on the same page) we run out of space and do a page split
5. We attempt to re-execute _all the changes_ in the now-split Page again ([delete, insert, insert, insert, insert])
6. The value is already deleted in the Page so we throw an error attempting to delete it for a second time

This PR fixes this issue by not throwing an error if the value doesn't exist. Instead it just returns a pointer to the current (unchanged) node so all parent nodes above will update their pointers to the cloned page, or continues writing the changes, skipping the non-existent value
