### PR TITLE
fix: Writer Should Use Previous Snapshot in Transaction Manager

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -166,7 +166,9 @@ impl<P: PageManager> Database<P> {
         let storage_engine = self.inner.storage_engine.read().unwrap();
         let metadata = self.inner.metadata.read().unwrap().next();
         let min_snapshot_id = transaction_manager.begin_rw(metadata.snapshot_id)?;
-        storage_engine.unlock(min_snapshot_id - 1);
+        if min_snapshot_id > 0 {
+            storage_engine.unlock(min_snapshot_id - 1);
+        }
         let context = TransactionContext::new(metadata);
         Ok(Transaction::new(context, self, None))
     }


### PR DESCRIPTION
The writer should use `snapshot_id - 1` in the transaction to prevent previous version pages from getting orphaned an unlocked. This guarantees that there will always be at least 1 full version of the Trie at all times.

Consider the following example:
1. Latest snapshot_id of trie pages is 4
2. A new writer attempts to change the trie with a snapshot id of 5
3. This writer begins to clone and orphan pages
4. The database is closed -- causing these orphan pages to be written to disk
5. Upon startup, the pages of the latest complete trie are considered orphan, making it unstable for readers to read from