### PR TITLE
feat: dynamic children size of a branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 alloy-primitives = { version = "0.8.21", features = ["arbitrary", "rand"] }
 alloy-rlp = "0.3.11"
-alloy-trie = { version = "0.7.6", features=["arbitrary", "ethereum"]}
+alloy-trie = { version = "0.7.6", features = ["arbitrary", "ethereum"] }
 arrayvec = "0.7.6"
 log = "0.4.25"
 memmap2 = "0.9.5"
@@ -27,4 +27,5 @@ name = "database_benchmarks"
 harness = false
 
 [profile.bench]
-debug = true
+debug = false
+opt-level = 3

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,22 +1,15 @@
-use crate::metrics::DatabaseMetrics;
-use crate::metrics::TransactionMetrics;
-use crate::page::MmapPageManager;
-use crate::page::OrphanPageManager;
-use crate::page::PageError;
-use crate::page::PageId;
-use crate::page::PageKind;
-use crate::page::PageManager;
-use crate::page::RootPage;
-use crate::snapshot::SnapshotId;
-use crate::storage::engine;
-use crate::storage::engine::StorageEngine;
-use crate::transaction::Transaction;
-use crate::transaction::TransactionManager;
-use crate::transaction::{RO, RW};
+use crate::{
+    metrics::{DatabaseMetrics, TransactionMetrics},
+    page::{
+        MmapPageManager, OrphanPageManager, PageError, PageId, PageKind, PageManager, RootPage,
+    },
+    snapshot::SnapshotId,
+    storage::{engine, engine::StorageEngine},
+    transaction::{Transaction, TransactionManager, RO, RW},
+};
 use alloy_primitives::B256;
 use alloy_trie::EMPTY_ROOT_HASH;
-use std::sync::Arc;
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 
 #[derive(Debug, Clone)]
 pub struct Database<P: PageManager> {

--- a/src/node.rs
+++ b/src/node.rs
@@ -748,6 +748,44 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_branch_node_encode_decode() {
+        let nibbles = Nibbles::from_nibbles([0x1, 0x2, 0x3, 0x4]);
+        let mut node: Node<AccountVec> = Node::new_branch(nibbles);
+        node.set_child(
+            0,
+            Pointer::new(
+                0.into(),
+                RlpNode::word_rlp(&b256!(
+                    "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+                )),
+            ),
+        );
+        node.set_child(
+            1,
+            Pointer::new(
+                1.into(),
+                RlpNode::word_rlp(&b256!(
+                    "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+                )),
+            ),
+        );
+        node.set_child(
+            2,
+            Pointer::new(
+                2.into(),
+                RlpNode::word_rlp(&b256!(
+                    "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+                )),
+            ),
+        );
+        assert_eq!(node.size(), 2 + 4 + 2 + 36 * 16);
+
+        let x = node.serialize().unwrap();
+        let y = Node::from_bytes(&x).unwrap();
+        assert_eq!(node, y);
+    }
+
     proptest! {
         #[test]
         fn fuzz_node_to_from_bytes(node: Node<AccountVec>) {

--- a/src/node.rs
+++ b/src/node.rs
@@ -441,7 +441,7 @@ impl Node {
     fn children_slot_size(children: &[Option<Pointer>]) -> (usize, usize) {
         // children is saved in a list of 2, 4, 8, 16 slots depending on the number of children
         const MIN_SLOT_SIZE: usize = 2;
-        let total_children = children.into_iter().filter(|child| child.is_some()).count();
+        let total_children = children.iter().filter(|child| child.is_some()).count();
         let slot_size = max(total_children.next_power_of_two(), MIN_SLOT_SIZE);
         (total_children, slot_size)
     }
@@ -797,7 +797,7 @@ mod tests {
         expected.extend([0, 0, 0, 210, 160]);
         expected.extend(hash3.as_slice());
         // remaining empty slot
-        expected.extend([0; 37 * 1]);
+        expected.extend([0; 37]);
         assert_eq!(bytes, expected);
 
         let mut node: Node = Node::new_branch(Nibbles::from_nibbles([0x0, 0x0]));

--- a/src/node.rs
+++ b/src/node.rs
@@ -267,13 +267,15 @@ impl<V: Value> Value for Node<V> {
                     .unwrap(),
             );
             let mut children = [const { None }; 16];
+            let mut block_count = 0;
             for (i, child) in children.iter_mut().enumerate() {
                 if children_bitmask & (1 << (15 - i)) == 0 {
                     continue;
                 }
-                let child_offset = 4 + packed_prefix_length + i * 37;
+                let child_offset = 4 + packed_prefix_length + block_count * 37;
                 let child_bytes = &bytes[child_offset..child_offset + 37];
                 *child = Some(Pointer::from_bytes(child_bytes)?);
+                block_count += 1;
             }
             Ok(Self::Branch { prefix, children })
         }
@@ -852,7 +854,7 @@ mod tests {
             ),
         );
         node.set_child(
-            1,
+            10,
             Pointer::new(
                 1.into(),
                 RlpNode::word_rlp(&b256!(

--- a/src/node.rs
+++ b/src/node.rs
@@ -218,9 +218,8 @@ impl Value for Node {
             Self::Branch { prefix, children } => {
                 let (_, children_slot_size) = Self::children_slot_size(children);
 
-                let prefix_length = prefix.len();
-                let packed_prefix_length = (prefix_length + 1) / 2;
-                return 2 + packed_prefix_length + 2 + children_slot_size * 37; // 2 bytes for type and prefix length, 2 for bitmask, 37 for each child pointer
+                let packed_prefix_length = (prefix.len() + 1) / 2;
+                2 + packed_prefix_length + 2 + children_slot_size * 37 // 2 bytes for type and prefix length, 2 for bitmask, 37 for each child pointer
             }
         }
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -295,8 +295,7 @@ impl Value for Node {
 
                 let prefix_length = prefix.len();
                 let packed_prefix_length = (prefix_length + 1) / 2;
-                let mut total_size = 2 + packed_prefix_length + 2; // Type, prefix length, bitmask
-                total_size += children_slot_size * 37; // Each pointer is 37 bytes
+                let total_size = 2 + packed_prefix_length + 2 + children_slot_size * 37; // Type, prefix length, bitmask + children pointers
 
                 if buf.len() < total_size {
                     return Err(value::Error::InvalidEncoding);

--- a/src/node.rs
+++ b/src/node.rs
@@ -616,7 +616,7 @@ mod tests {
 
         // 4 children, reserve 4 children slots
         let mut node = Node::new_branch(Nibbles::new());
-        for i in 0..4 {
+        for i in 10..14 {
             node.set_child(
                 i,
                 Pointer::new((i as u32).into(), RlpNode::from_rlp(&encode(i))),
@@ -627,7 +627,7 @@ mod tests {
 
         // 5 children, reserve 8 children slots
         let mut node = Node::new_branch(Nibbles::new());
-        for i in 0..5 {
+        for i in 11..16 {
             node.set_child(
                 i,
                 Pointer::new((i as u32).into(), RlpNode::from_rlp(&encode(i))),
@@ -638,7 +638,7 @@ mod tests {
 
         // 8 children, reserve 8 children slots
         let mut node = Node::new_branch(Nibbles::new());
-        for i in 0..8 {
+        for i in 5..13 {
             node.set_child(
                 i,
                 Pointer::new((i as u32).into(), RlpNode::from_rlp(&encode(i))),
@@ -649,7 +649,7 @@ mod tests {
 
         // 9 children, reserve 16 children slots
         let mut node = Node::new_branch(Nibbles::new());
-        for i in 0..9 {
+        for i in 3..12 {
             node.set_child(
                 i,
                 Pointer::new((i as u32).into(), RlpNode::from_rlp(&encode(i))),

--- a/src/page.rs
+++ b/src/page.rs
@@ -9,5 +9,4 @@ pub use manager::{PageError, PageId, PageManager};
 pub use orphan::OrphanPageManager;
 pub use page::{Page, PageKind, PAGE_DATA_SIZE, PAGE_SIZE, RO, RW};
 pub use root::RootPage;
-pub use slotted_page::SlottedPage;
-pub use slotted_page::CELL_POINTER_SIZE;
+pub use slotted_page::{SlottedPage, CELL_POINTER_SIZE};

--- a/src/page.rs
+++ b/src/page.rs
@@ -10,3 +10,4 @@ pub use orphan::OrphanPageManager;
 pub use page::{Page, PageKind, PAGE_DATA_SIZE, PAGE_SIZE, RO, RW};
 pub use root::RootPage;
 pub use slotted_page::SlottedPage;
+pub use slotted_page::CELL_POINTER_SIZE;

--- a/src/page.rs
+++ b/src/page.rs
@@ -4,8 +4,7 @@ mod page;
 mod root;
 mod slotted_page;
 
-pub use manager::mmap::MmapPageManager;
-pub use manager::{PageError, PageId, PageManager};
+pub use manager::{mmap::MmapPageManager, PageError, PageId, PageManager};
 pub use orphan::OrphanPageManager;
 pub use page::{Page, PageKind, PAGE_DATA_SIZE, PAGE_SIZE, RO, RW};
 pub use root::RootPage;

--- a/src/page/manager/mmap.rs
+++ b/src/page/manager/mmap.rs
@@ -1,8 +1,12 @@
 use std::fs::File;
 
-use crate::page::page::{RO, RW};
-use crate::page::{Page, PageError, PageId, PageManager, PAGE_SIZE};
-use crate::snapshot::SnapshotId;
+use crate::{
+    page::{
+        page::{RO, RW},
+        Page, PageError, PageId, PageManager, PAGE_SIZE,
+    },
+    snapshot::SnapshotId,
+};
 use memmap2::MmapMut;
 
 // Manages pages in a memory mapped file.

--- a/src/page/orphan.rs
+++ b/src/page/orphan.rs
@@ -1,5 +1,4 @@
-use crate::page::PageId;
-use crate::snapshot::SnapshotId;
+use crate::{page::PageId, snapshot::SnapshotId};
 use std::collections::BTreeMap;
 
 // Manages a collection of orphaned page ids, grouped by the snapshot id which created them.

--- a/src/page/page.rs
+++ b/src/page/page.rs
@@ -1,7 +1,6 @@
 use sealed::sealed;
 
-use crate::page::PageId;
-use crate::snapshot::SnapshotId;
+use crate::{page::PageId, snapshot::SnapshotId};
 
 pub const PAGE_SIZE: usize = 4096;
 pub const HEADER_SIZE: usize = 8;

--- a/src/page/root.rs
+++ b/src/page/root.rs
@@ -1,7 +1,6 @@
 use crate::{page::Page, snapshot::SnapshotId};
 use alloy_primitives::B256;
-use std::collections::VecDeque;
-use std::iter::Peekable;
+use std::{collections::VecDeque, iter::Peekable};
 
 use super::{
     page::{PageKind, RO, RW},
@@ -275,8 +274,7 @@ impl<'p, P: PageKind> TryFrom<Page<'p, P>> for RootPage<'p, P> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::page::MmapPageManager;
-    use crate::page::PAGE_DATA_SIZE;
+    use crate::page::{MmapPageManager, PAGE_DATA_SIZE};
 
     const MAX_ORPHANS: usize = 1011;
 

--- a/src/page/slotted_page.rs
+++ b/src/page/slotted_page.rs
@@ -985,7 +985,7 @@ mod tests {
                 .unwrap();
         }
 
-        slotted_page.defragment(5, 595).unwrap();
+        slotted_page.defragment(4, 595).unwrap();
 
         let expected_cell_pointers = [
             (595, 595),

--- a/src/page/slotted_page.rs
+++ b/src/page/slotted_page.rs
@@ -126,6 +126,9 @@ impl SlottedPage<'_, RW> {
         if value_length > length as usize {
             // the value is larger than the current cell, so we need to allocate a new cell
             let cell_pointer = self.allocate_cell_pointer(index, value_length as u16)?;
+            // TODO: if error is PageIsFull, we should split the page
+            // This is the place when a branch node go from 8 -> 9 children increase size from 300 -> 596
+
             (offset, length) = (cell_pointer.offset(), cell_pointer.length());
         } else if value_length < length as usize {
             // the value is smaller than the current cell, so we can shrink the cell in place

--- a/src/page/slotted_page.rs
+++ b/src/page/slotted_page.rs
@@ -218,8 +218,9 @@ impl SlottedPage<'_, RW> {
 
         let total_occupied_space = self
             .cell_pointers_iter()
-            .filter(|cp| !cp.is_deleted())
-            .map(|cp| cp.length())
+            .enumerate()
+            .filter(|(i, cp)| *i != index as usize && !cp.is_deleted())
+            .map(|(_, cp)| cp.length())
             .sum::<u16>();
 
         let new_num_cells = max(num_cells, index + 1);
@@ -232,7 +233,7 @@ impl SlottedPage<'_, RW> {
         let mut cell_pointers = self
             .cell_pointers_iter()
             .enumerate()
-            .filter(|(_, cp)| !cp.is_deleted())
+            .filter(|(i, cp)| *i != index as usize && !cp.is_deleted())
             .map(|(i, cp)| (i, cp.offset(), cp.length()))
             .collect::<Vec<_>>();
 

--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -414,7 +414,6 @@ impl<P: PageManager> StorageEngine<P> {
                 node.set_child(child_index, Pointer::new(location, rlp_node));
                 let rlp_node_with_child = node.rlp_encode();
                 slotted_page.set_value(page_index, node)?;
-                // TODO: if error is PageIsFull, we should split the page
 
                 Ok(Pointer::new(
                     self.node_location(slotted_page.page_id(), page_index),

--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -440,7 +440,8 @@ impl<P: PageManager> StorageEngine<P> {
                 // the child node does not exist, so we need to create a new leaf node with the remaining path.
                 // ensure that the page has enough space (300 bytes) to insert a new leaf node.
                 // TODO: use a more accurate threshold
-                if slotted_page.num_free_bytes() < 300 {
+                // Add buffer of 300 bytes when children number go from 8 -> 9 (+296)
+                if slotted_page.num_free_bytes() < 300 + 300 {
                     self.split_page::<V>(context, slotted_page)?;
                     return Err(Error::PageSplit);
                 }
@@ -460,6 +461,8 @@ impl<P: PageManager> StorageEngine<P> {
 
                 let rlp_node_with_child = node.rlp_encode();
                 slotted_page.set_value(page_index, node)?;
+                // TODO: if error is PageIsFull, we should split the page
+
                 Ok(Pointer::new(
                     self.node_location(slotted_page.page_id(), page_index),
                     rlp_node_with_child,

--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -445,7 +445,14 @@ impl<P: PageManager> StorageEngine<P> {
                     self.split_page::<V>(context, slotted_page)?;
                     return Err(Error::PageSplit);
                 }
+                let new_node1 = Node::new_leaf(remaining_path.clone(), value.clone(), leaf_type);
+
                 let new_node = Node::new_leaf(remaining_path, value, leaf_type);
+
+                eprintln!("=== new_node size: {}", new_node1.size());
+                eprintln!("slotted_page size: {}", slotted_page.num_free_bytes());
+                eprintln!("node size: {}", node.size());
+
                 let rlp_node = new_node.rlp_encode();
                 let location = Location::for_cell(slotted_page.insert_value(new_node)?);
                 node.set_child(child_index, Pointer::new(location, rlp_node.clone()));
@@ -458,6 +465,10 @@ impl<P: PageManager> StorageEngine<P> {
                         page_index,
                     );
                 }
+
+                eprintln!("slotted_page size: {}", slotted_page.num_free_bytes());
+                eprintln!("node size: {}", node.size());
+                eprintln!("page_index: {}", page_index);
 
                 let rlp_node_with_child = node.rlp_encode();
                 slotted_page.set_value(page_index, node)?;

--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -12,10 +12,11 @@ use crate::{
     snapshot::SnapshotId,
 };
 use alloy_trie::{nodes::RlpNode, Nibbles, EMPTY_ROOT_HASH};
-use std::cmp::max;
-use std::fmt::Debug;
-use std::sync::Arc;
-use std::sync::RwLock;
+use std::{
+    cmp::max,
+    fmt::Debug,
+    sync::{Arc, RwLock},
+};
 
 use alloy_primitives::StorageValue;
 
@@ -2019,8 +2020,7 @@ mod tests {
 
     #[test]
     fn test_split_page_random_accounts() {
-        use rand::rngs::StdRng;
-        use rand::{Rng, SeedableRng};
+        use rand::{rngs::StdRng, Rng, SeedableRng};
 
         // Create a storage engine
         let (storage_engine, mut context) = create_test_engine(2000, 256);


### PR DESCRIPTION
## New feature
- Branch children slots is dynamically level up based on the actual number of children it has. 
- Branch node had 16 children from beginning, its going up from 2 -> 4 -> 8 -> 16 depends on the children number.
- Focus on inserting operation now. Delete operation will be in another PR

### DB size different

When insert 5M random accounts:

```
-rw-r--r--   1 dinh  staff   2.1G Mar  7 15:49 new_test.db
-rw-r--r--   1 dinh  staff   3.3G Mar  7 11:32 original_test.db
```

The DB size from 3.3G to 2.1GB (36% lower).

### Benchmark

Comparing vs main branch: Every operation has sig improvement


```
    Finished `bench` profile [optimized] target(s) in 2.89s
     Running benches/database_benchmarks.rs (target/release/deps/database_benchmarks-d3a2ea7ffdc49b47)
Gnuplot not found, using plotters backend
read_operations/random_reads/1000000
                        time:   [18.362 ms 18.600 ms 18.881 ms]
                        thrpt:  [529.63 Kelem/s 537.63 Kelem/s 544.61 Kelem/s]
                 change:
                        time:   [-12.831% -9.5303% -6.3249%] (p = 0.00 < 0.05)
                        thrpt:  [+6.7519% +10.534% +14.719%]
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe
read_operations/random_reads/3000000
                        time:   [19.861 ms 20.248 ms 20.679 ms]
                        thrpt:  [483.57 Kelem/s 493.87 Kelem/s 503.51 Kelem/s]
                 change:
                        time:   [-9.4646% -6.2291% -3.1422%] (p = 0.00 < 0.05)
                        thrpt:  [+3.2441% +6.6429% +10.454%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe

Benchmarking insert_operations/batch_inserts/1000000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 19.3s, or reduce sample count to 20.
insert_operations/batch_inserts/1000000
                        time:   [185.48 ms 194.28 ms 203.16 ms]
                        thrpt:  [49.222 Kelem/s 51.473 Kelem/s 53.914 Kelem/s]
                 change:
                        time:   [-35.777% -31.564% -27.012%] (p = 0.00 < 0.05)
                        thrpt:  [+37.009% +46.121% +55.708%]
                        Performance has improved.
Benchmarking insert_operations/batch_inserts/3000000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 30.3s, or reduce sample count to 10.
insert_operations/batch_inserts/3000000
                        time:   [294.75 ms 310.06 ms 325.49 ms]
                        thrpt:  [30.723 Kelem/s 32.252 Kelem/s 33.928 Kelem/s]
                 change:
                        time:   [-28.447% -22.304% -15.203%] (p = 0.00 < 0.05)
                        thrpt:  [+17.928% +28.706% +39.757%]
                        Performance has improved.

Benchmarking update_operations/batch_updates/1000000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 19.5s, or reduce sample count to 20.
update_operations/batch_updates/1000000
                        time:   [183.54 ms 191.70 ms 199.97 ms]
                        thrpt:  [50.007 Kelem/s 52.166 Kelem/s 54.484 Kelem/s]
                 change:
                        time:   [-35.235% -30.713% -26.049%] (p = 0.00 < 0.05)
                        thrpt:  [+35.224% +44.328% +54.404%]
                        Performance has improved.
Benchmarking update_operations/batch_updates/3000000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 31.8s, or reduce sample count to 10.
update_operations/batch_updates/3000000
                        time:   [318.92 ms 340.82 ms 362.98 ms]
                        thrpt:  [27.550 Kelem/s 29.341 Kelem/s 31.356 Kelem/s]
                 change:
                        time:   [-53.067% -37.995% -19.616%] (p = 0.00 < 0.05)
                        thrpt:  [+24.403% +61.278% +113.07%]
                        Performance has improved.

delete_operations/batch_deletes/1000000
                        time:   [2.5437 ms 2.6650 ms 2.8285 ms]
                        thrpt:  [3.5354 Melem/s 3.7524 Melem/s 3.9312 Melem/s]
                 change:
                        time:   [-96.201% -96.008% -95.761%] (p = 0.00 < 0.05)
                        thrpt:  [+2259.1% +2405.2% +2532.1%]
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  7 (7.00%) high mild
  6 (6.00%) high severe
Benchmarking delete_operations/batch_deletes/3000000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 10.0s, or reduce sample count to 40.
delete_operations/batch_deletes/3000000
                        time:   [70.923 ms 71.709 ms 72.545 ms]
                        thrpt:  [137.85 Kelem/s 139.45 Kelem/s 141.00 Kelem/s]
                 change:
                        time:   [-36.374% -21.824% -9.4852%] (p = 0.00 < 0.05)
                        thrpt:  [+10.479% +27.917% +57.168%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

Benchmarking mixed_operations/mixed_workload/1000000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 20.8s, or reduce sample count to 20.
mixed_operations/mixed_workload/1000000
                        time:   [204.91 ms 208.01 ms 211.39 ms]
                        thrpt:  [47.305 Kelem/s 48.075 Kelem/s 48.801 Kelem/s]
                 change:
                        time:   [-11.308% -9.3780% -7.4263%] (p = 0.00 < 0.05)
                        thrpt:  [+8.0220% +10.348% +12.749%]
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe
Benchmarking mixed_operations/mixed_workload/3000000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 32.7s, or reduce sample count to 10.
mixed_operations/mixed_workload/3000000
                        time:   [334.47 ms 339.21 ms 344.83 ms]
                        thrpt:  [29.000 Kelem/s 29.480 Kelem/s 29.898 Kelem/s]
                 change:
                        time:   [-41.046% -33.475% -27.095%] (p = 0.00 < 0.05)
                        thrpt:  [+37.165% +50.319% +69.623%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
```
