### PR TITLE
chore: Add test and benchmark targets to Makefile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ criterion = "0.5"
 tempdir = "0.3.7"
 rand = "0.8.5"
 
+[lib]
+bench = false
+
 [[bench]]
 name = "database_benchmarks"
 harness = false

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,15 @@
+BASELINE := main
+
 # this will modify files in place
 format:
+	@cargo clippy --fix
 	@cargo fmt
+
+bench-baseline:
+	@cargo bench -- --save-baseline $(shell git rev-parse --abbrev-ref HEAD)
+
+bench-compare:
+	@cargo bench -- --baseline $(BASELINE)
+
+test:
+	@cargo test


### PR DESCRIPTION
Add `bench-baseline`, `bench-compare`, and `test` targets, and updates `format` to also invoke clippy