### PR TITLE
fix: Ensure database can be properly reopened after close

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -345,10 +345,8 @@ impl Value for Node {
 
                 // Store each child pointer
                 let mut offset = 2 + packed_prefix_length + 2;
-                for child in children.iter() {
-                    if let Some(child) = child {
-                        offset += child.serialize_into(&mut buf[offset..offset + 37])?;
-                    }
+                for child in children.iter().flatten() {
+                    offset += child.serialize_into(&mut buf[offset..offset + 37])?;
                 }
                 let padding_size = (children_slot_size - total_children) * 37;
                 buf[offset..offset + padding_size].fill(0);

--- a/src/page/root.rs
+++ b/src/page/root.rs
@@ -104,9 +104,15 @@ impl<P: PageKind> RootPage<'_, P> {
 }
 
 impl<'p> RootPage<'p, RW> {
-    pub fn new(mut page_mut: Page<'p, RW>, state_root: B256, max_page_number: PageId) -> Self {
+    pub fn new(
+        mut page_mut: Page<'p, RW>,
+        state_root: B256,
+        root_subtrie_page_id: PageId,
+        max_page_number: PageId,
+    ) -> Self {
         let contents = page_mut.contents_mut();
         contents[0..32].copy_from_slice(state_root.as_slice());
+        contents[32..36].copy_from_slice(&root_subtrie_page_id.to_le_bytes());
         contents[36..40].copy_from_slice(&max_page_number.to_le_bytes());
 
         Self { page: page_mut }
@@ -283,7 +289,7 @@ mod tests {
         // GIVEN: a root page with orphan ids
         let mut page_manager = MmapPageManager::new_anon(20, 0).unwrap();
         let page = page_manager.allocate(42).unwrap();
-        let mut root_page = RootPage::new(page, B256::default(), 0);
+        let mut root_page = RootPage::new(page, B256::default(), 0, 0);
         let my_orphan_page_ids: &[PageId] = &[2, 3, 4, 5, 6, 7, 8, 9, 10];
         root_page
             .add_orphaned_page_ids(my_orphan_page_ids, 0, &mut page_manager)
@@ -301,7 +307,7 @@ mod tests {
         // GIVEN: a root page with no orphan ids
         let mut page_manager = MmapPageManager::new_anon(20, 0).unwrap();
         let page = page_manager.allocate(42).unwrap();
-        let root_page = RootPage::new(page, B256::default(), 0);
+        let root_page = RootPage::new(page, B256::default(), 0, 0);
 
         // WHEN: the list of orphan ids are requested
         let orphan_page_ids = root_page.get_orphaned_page_ids(&page_manager).unwrap();
@@ -319,7 +325,7 @@ mod tests {
         let mut page2 = page_manager.allocate(42).unwrap();
         let mut my_orphan_page_ids: Vec<PageId> = Vec::new();
 
-        let mut root_page = RootPage::new(page0, B256::default(), 0);
+        let mut root_page = RootPage::new(page0, B256::default(), 0, 0);
         // we should be able to store MAX_ORPHANS orphan page ids in a root page.
         // the last 4 bytes of the root page will be the next page id containing
         // the remainder of the list of orphan page ids
@@ -361,7 +367,7 @@ mod tests {
         // GIVEN: a root page with a list of orphan page ids
         let mut page_manager = MmapPageManager::new_anon(20, 0).unwrap();
         let page = page_manager.allocate(42).unwrap();
-        let mut root_page = RootPage::new(page, B256::default(), 0);
+        let mut root_page = RootPage::new(page, B256::default(), 0, 0);
         let my_orphan_page_ids: &[PageId] = &[1, 2, 3, 4, 5, 6, 7, 8, 9];
         root_page
             .add_orphaned_page_ids(&my_orphan_page_ids.to_vec(), 0, &mut page_manager)
@@ -389,7 +395,7 @@ mod tests {
         // GIVEN: a root page with a list of orphan page ids spanning 2 pages
         let mut page_manager = MmapPageManager::new_anon(20, 0).unwrap();
         let page = page_manager.allocate(42).unwrap();
-        let mut root_page = RootPage::new(page, B256::default(), 0);
+        let mut root_page = RootPage::new(page, B256::default(), 0, 0);
 
         // page 0 allocated. our pages for this test will spill into page 2
         // so allocate at least 2 more pages.
@@ -434,7 +440,7 @@ mod tests {
         // GIVEN: a root page with a list of orphan page ids spanning 2 pages
         let mut page_manager = MmapPageManager::new_anon(20, 0).unwrap();
         let page = page_manager.allocate(42).unwrap();
-        let mut root_page = RootPage::new(page, B256::default(), 0);
+        let mut root_page = RootPage::new(page, B256::default(), 0, 0);
 
         // page 0 allocated. our pages for this test will spill into page 2
         // so allocate at least 2 more pages.
@@ -486,7 +492,7 @@ mod tests {
         let mut page_manager = MmapPageManager::new_anon(257, 0).unwrap();
         let page0 = page_manager.allocate(42).unwrap();
         assert_eq!(page0.page_id(), 0);
-        let mut root_page = RootPage::new(page0, B256::default(), 0);
+        let mut root_page = RootPage::new(page0, B256::default(), 0, 0);
 
         let page1 = page_manager.allocate(42).unwrap();
         assert_eq!(page1.page_id(), 1);
@@ -515,7 +521,7 @@ mod tests {
         let mut page_manager = MmapPageManager::new_anon(20, 0).unwrap();
         let page0 = page_manager.allocate(42).unwrap();
         assert_eq!(page0.page_id(), 0);
-        let mut root_page = RootPage::new(page0, B256::default(), 0);
+        let mut root_page = RootPage::new(page0, B256::default(), 0, 0);
 
         let page1 = page_manager.allocate(42).unwrap();
         assert_eq!(page1.page_id(), 1);
@@ -565,7 +571,7 @@ mod tests {
         let mut page_manager = MmapPageManager::new_anon(257, 0).unwrap();
         let page = page_manager.allocate(42).unwrap();
         assert_eq!(page.page_id(), 0);
-        let mut root_page = RootPage::new(page, B256::default(), 0);
+        let mut root_page = RootPage::new(page, B256::default(), 0, 0);
 
         // page 0 allocated. allocate 255 more pages
         for _ in 1..256 {
@@ -617,7 +623,7 @@ mod tests {
         let mut page_manager = MmapPageManager::new_anon(257, 0).unwrap();
         let page = page_manager.allocate(42).unwrap();
         assert_eq!(page.page_id(), 0);
-        let mut root_page = RootPage::new(page, B256::default(), 0);
+        let mut root_page = RootPage::new(page, B256::default(), 0, 0);
 
         // page 0 allocated. allocate 255 more pages
         for _ in 1..256 {
@@ -655,7 +661,7 @@ mod tests {
         // GIVEN: a root page with orphan ids
         let mut page_manager = MmapPageManager::new_anon(20, 0).unwrap();
         let page = page_manager.allocate(42).unwrap();
-        let mut root_page = RootPage::new(page, B256::default(), 0);
+        let mut root_page = RootPage::new(page, B256::default(), 0, 0);
         let my_orphan_page_ids: &[PageId] = &[2, 3, 4, 5, 6, 7, 8, 9, 10];
         root_page
             .add_orphaned_page_ids(my_orphan_page_ids, 0, &mut page_manager)


### PR DESCRIPTION
Ensure that the `root_subtrie_page_id` is persisted in the root page, and that the truncated file size includes all the max page id.

Cleans up the storage engine behavior when the trie is empty, by instead setting the `root_subtrie_page_id` to 0. This no longer returns an error when attempting to `get_account` or `get_storage` when the trie is empty, and instead returns `None`.