### PR TITLE
fix: Safe Increment Unlocked Pages

### DIFF
--- a/src/page/orphan.rs
+++ b/src/page/orphan.rs
@@ -36,8 +36,9 @@ impl OrphanPageManager {
 
     // Returns an unlocked orphaned page id, if one exists.
     pub fn get_orphaned_page_id(&mut self) -> Option<PageId> {
-        self.num_orphan_pages_used += 1;
-        self.unlocked_page_ids.pop()
+        self.unlocked_page_ids.pop().inspect(|_| {
+            self.num_orphan_pages_used += 1;
+        })
     }
 
     // Unlocks all pages that were locked as of the given snapshot id.


### PR DESCRIPTION
Closes: https://github.com/base/triedb/issues/61

See issue for more details. 

We should revisit if we need to return `locked_page_ids` from the orphan manager when writing the page ids to disk, as on startup, they become marked as orphaned even though they may be in use