### PR TITLE
trivial: Assert Infinite Allocate Page Loop

### DIFF
--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -1015,6 +1015,10 @@ impl<P: PageManager> StorageEngine<P> {
 
             // Move the subtrie to the new page
             let cell_index = largest_child_pointer.location().cell_index().expect(
+                // although we dont expect this case to occur in practice, this check is useful during development
+                // to make sure we don't accidentally malform slotted pages. For example, if we explicitly set an
+                // account with an EMPTY_ROOT_HASH as storage root, we may accidentally orphan all of it's storage
+                // trie on the same page, triggering this case to happen.
                 "largest child pointer doesn't exist on the same page. infinite loop detected.",
             );
             // Move all child nodes that are in the current page


### PR DESCRIPTION
This PR adds an assertion to make sure we don't infinitely loop allocation pages during a page split.

I encountered this during development because our benchmark tests explicitly set account with an empty storage hash (e.g in the **mixed_operations** test). If that account has storage, we accidentally orphan all that storage on the page without cleaning it up, causing this infinite loop bug to occur (even after moving the root node's children to different pages, because the rest of the page still contains the inaccessible storage nodes, we just end up looping forever till we are out of pages) 