### PR TITLE
fix: Ensure that leaf resizing does not trigger a page full error

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -1,12 +1,15 @@
 use alloy_primitives::{B256, U256};
+use alloy_trie::{EMPTY_ROOT_HASH, KECCAK_EMPTY};
+use proptest::prelude::*;
 use proptest_derive::Arbitrary;
-use std::fmt::Debug;
 
 #[derive(Debug, Clone, PartialEq, Eq, Arbitrary)]
 pub struct Account {
     pub nonce: u64,
     pub balance: U256,
+    #[proptest(strategy = "prop_oneof!(any::<B256>(), Just(EMPTY_ROOT_HASH))")]
     pub storage_root: B256,
+    #[proptest(strategy = "prop_oneof!(any::<B256>(), Just(KECCAK_EMPTY))")]
     pub code_hash: B256,
 }
 
@@ -19,8 +22,6 @@ impl Account {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    use proptest::prelude::*;
 
     proptest! {
         #[test]

--- a/src/node.rs
+++ b/src/node.rs
@@ -247,6 +247,13 @@ impl Node {
                 let next_slot_size = max(next_total_children.next_power_of_two(), 2);
                 (next_slot_size - slot_size) * 37
             }
+            Self::AccountLeaf { storage_root, .. } => {
+                if storage_root.is_none() {
+                    37
+                } else {
+                    0
+                }
+            }
             _ => 0,
         }
     }


### PR DESCRIPTION
Handle two conditions where a leaf's contents might cause it to overflow its page:
1. Adding a storage root to an account, which directly increases the serialized size by 37 bytes
2. Changing the value itself (due to variable length serialization, omitting of default values)

Adds storage engine fuzz tests which were able to trigger these error cases:
1. Insert a random set of accounts, each with a variable number of random storage slots, all in one batch write (triggered case 1)
2. Insert a random set of accounts, each with a variable number of revisions. Performs write batches for each revision. (triggered case 2 by resizing account internals)

Also intentionally biases the arbitrary account generation to select between random storage roots and the empty root hash, as well as between random code hashes and the empty keccak. This ensures that the default values are actually used in fuzz tests, which are serialized differently.

**note that the fuzz tests may take a long time to run unless built with optimizations `(cargo test -r)`**