### PR TITLE
Add `TransactionError`

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     snapshot::SnapshotId,
     storage::engine::{self, StorageEngine},
-    transaction::{Transaction, TransactionManager, RO, RW},
+    transaction::{Transaction, TransactionError, TransactionManager, RO, RW},
 };
 use alloy_primitives::B256;
 use alloy_trie::{Nibbles, EMPTY_ROOT_HASH};
@@ -149,7 +149,7 @@ impl<P: PageManager> Database<P> {
         }
     }
 
-    pub fn begin_rw(&self) -> Result<Transaction<'_, RW, P>, ()> {
+    pub fn begin_rw(&self) -> Result<Transaction<'_, RW, P>, TransactionError> {
         let mut transaction_manager = self.inner.transaction_manager.write().unwrap();
         let storage_engine = self.inner.storage_engine.read().unwrap();
         let metadata = self.inner.metadata.read().unwrap().next();
@@ -161,7 +161,7 @@ impl<P: PageManager> Database<P> {
         Ok(Transaction::new(context, self, None))
     }
 
-    pub fn begin_ro(&self) -> Result<Transaction<'_, RO, P>, ()> {
+    pub fn begin_ro(&self) -> Result<Transaction<'_, RO, P>, TransactionError> {
         let mut transaction_manager = self.inner.transaction_manager.write().unwrap();
         let storage_engine = self.inner.storage_engine.read().unwrap();
         let metadata = self.inner.metadata.read().unwrap().clone();
@@ -175,7 +175,7 @@ impl<P: PageManager> Database<P> {
         metadata.state_root
     }
 
-    pub(crate) fn resize(&self, new_page_count: PageId) -> Result<(), ()> {
+    pub(crate) fn resize(&self, new_page_count: PageId) -> Result<(), TransactionError> {
         let mut storage_engine = self.inner.storage_engine.write().unwrap();
         storage_engine.resize(new_page_count).unwrap();
         Ok(())

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,3 +1,4 @@
+mod error;
 mod manager;
 
 use std::{fmt::Debug, sync::RwLockReadGuard};
@@ -12,6 +13,7 @@ use crate::{
 };
 use alloy_primitives::{StorageValue, B256};
 use alloy_trie::Nibbles;
+pub use error::TransactionError;
 pub use manager::TransactionManager;
 use sealed::sealed;
 use std::collections::HashMap;
@@ -57,7 +59,10 @@ impl<'tx, K: TransactionKind, P: PageManager> Transaction<'tx, K, P> {
         }
     }
 
-    pub fn get_account(&'tx self, address_path: AddressPath) -> Result<Option<Account>, ()> {
+    pub fn get_account(
+        &'tx self,
+        address_path: AddressPath,
+    ) -> Result<Option<Account>, TransactionError> {
         let storage_engine = self.database.inner.storage_engine.read().unwrap();
         let account = storage_engine.get_account(&self.context, address_path).unwrap();
 
@@ -66,7 +71,10 @@ impl<'tx, K: TransactionKind, P: PageManager> Transaction<'tx, K, P> {
         Ok(account)
     }
 
-    pub fn get_storage_slot(&self, storage_path: StoragePath) -> Result<Option<StorageValue>, ()> {
+    pub fn get_storage_slot(
+        &self,
+        storage_path: StoragePath,
+    ) -> Result<Option<StorageValue>, TransactionError> {
         let storage_engine = self.database.inner.storage_engine.read().unwrap();
         let storage_slot = storage_engine.get_storage(&self.context, storage_path).unwrap();
 
@@ -84,7 +92,7 @@ impl<P: PageManager> Transaction<'_, RW, P> {
         &mut self,
         address_path: AddressPath,
         account: Option<Account>,
-    ) -> Result<(), ()> {
+    ) -> Result<(), TransactionError> {
         self.pending_changes.insert(address_path.into(), account.map(TrieValue::Account));
         Ok(())
     }
@@ -93,12 +101,12 @@ impl<P: PageManager> Transaction<'_, RW, P> {
         &mut self,
         storage_path: StoragePath,
         value: Option<StorageValue>,
-    ) -> Result<(), ()> {
+    ) -> Result<(), TransactionError> {
         self.pending_changes.insert(storage_path.full_path(), value.map(TrieValue::Storage));
         Ok(())
     }
 
-    pub fn commit(mut self) -> Result<(), ()> {
+    pub fn commit(mut self) -> Result<(), TransactionError> {
         let storage_engine = self.database.inner.storage_engine.read().unwrap();
         let mut changes =
             self.pending_changes.drain().collect::<Vec<(Nibbles, Option<TrieValue>)>>();
@@ -133,7 +141,7 @@ impl<P: PageManager> Transaction<'_, RW, P> {
         Ok(())
     }
 
-    pub fn rollback(mut self) -> Result<(), ()> {
+    pub fn rollback(mut self) -> Result<(), TransactionError> {
         let mut transaction_manager = self.database.inner.transaction_manager.write().unwrap();
         let storage_engine = self.database.inner.storage_engine.read().unwrap();
         // TODO: this is temperorary until we actually implement rollback.
@@ -150,7 +158,7 @@ impl<P: PageManager> Transaction<'_, RW, P> {
 }
 
 impl<P: PageManager> Transaction<'_, RO, P> {
-    pub fn commit(mut self) -> Result<(), ()> {
+    pub fn commit(mut self) -> Result<(), TransactionError> {
         let mut transaction_manager = self.database.inner.transaction_manager.write().unwrap();
         transaction_manager.remove_transaction(self.context.metadata.snapshot_id, false)?;
 

--- a/src/transaction/error.rs
+++ b/src/transaction/error.rs
@@ -1,0 +1,12 @@
+use std::{error::Error, fmt};
+
+#[derive(Debug)]
+pub struct TransactionError;
+
+impl fmt::Display for TransactionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "transaction error")
+    }
+}
+
+impl Error for TransactionError {}


### PR DESCRIPTION
This fixes clippy warnings like the following:

```
warning: this returns a `Result<_, ()>`
  --> src/transaction/manager.rs:21:5
   |
21 |     pub fn begin_rw(&mut self, snapshot_id: SnapshotId) -> Result<SnapshotId, ()> {
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: use a custom `Error` type instead
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#result_unit_err
```