### PR TITLE
Suppress clippy warning about the size of `Node`

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -26,6 +26,8 @@ const EMPTY_ROOT_RLP: [u8; 33] =
 
 /// A node in the trie.
 /// This may be an account leaf, a storage leaf, or a branch.
+// TODO (PROTO-957): Consider wrapping this large struct into a Box
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, Eq, Arbitrary)]
 pub enum Node {
     AccountLeaf {


### PR DESCRIPTION
This struct may benefit from some refactoring, but for the time being it makes sense to just suppress the warning so that we can enforce clippy rules in the near future.

```
warning: large size difference between variants
  --> src/node.rs:30:1
   |
30 | /   pub enum Node {
31 | | /     AccountLeaf {
32 | | |         prefix: Nibbles,
33 | | |         #[proptest(strategy = "arb_u64_rlp()")]
34 | | |         nonce_rlp: ArrayVec<u8, 9>,
...  | |
38 | | |         storage_root: Option<Pointer>,
39 | | |     },
   | | |_____- the second-largest variant contains at least 208 bytes
...  |
45 | | /     Branch {
46 | | |         prefix: Nibbles,
47 | | |         #[proptest(strategy = "arb_children()")]
48 | | |         children: [Option<Pointer>; 16],
49 | | |     },
   | | |_____- the largest variant contains at least 840 bytes
50 | |   }
   | |___^ the entire enum is at least 840 bytes
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
   = note: `#[warn(clippy::large_enum_variant)]` on by default
```