### PR TITLE
Refactor `Page<RO|RW>` into `Page` and `PageMut`

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -1,8 +1,6 @@
 use crate::{
     metrics::{DatabaseMetrics, TransactionMetrics},
-    page::{
-        MmapPageManager, OrphanPageManager, PageError, PageId, PageKind, PageManager, RootPage,
-    },
+    page::{MmapPageManager, OrphanPageManager, PageError, PageId, PageManager, RootPage},
     snapshot::SnapshotId,
     storage::engine::{self, StorageEngine},
     transaction::{Transaction, TransactionError, TransactionManager, RO, RW},
@@ -77,7 +75,7 @@ impl Database<MmapPageManager> {
         page_manager.resize(1000).map_err(Error::PageError)?;
         for i in 0..256 {
             let page = page_manager.allocate(0).map_err(Error::PageError)?;
-            assert_eq!(page.page_id(), i);
+            assert_eq!(page.id(), i);
         }
 
         let orphan_manager = OrphanPageManager::new();
@@ -220,10 +218,10 @@ impl<P: PageManager> Database<P> {
     }
 }
 
-impl<'p, P: PageKind> From<RootPage<'p, P>> for Metadata {
-    fn from(root_page: RootPage<'p, P>) -> Self {
+impl<'p> From<RootPage<'p>> for Metadata {
+    fn from(root_page: RootPage<'p>) -> Self {
         Self {
-            root_page_id: root_page.page_id(),
+            root_page_id: root_page.id(),
             root_subtrie_page_id: root_page.root_subtrie_page_id(),
             max_page_number: root_page.max_page_number(),
             snapshot_id: root_page.snapshot_id(),

--- a/src/page.rs
+++ b/src/page.rs
@@ -6,6 +6,6 @@ mod slotted_page;
 
 pub use manager::{mmap::MmapPageManager, PageError, PageId, PageManager};
 pub use orphan::OrphanPageManager;
-pub use page::{Page, PageKind, PAGE_DATA_SIZE, PAGE_SIZE, RO, RW};
-pub use root::RootPage;
-pub use slotted_page::{SlottedPage, CELL_POINTER_SIZE};
+pub use page::{Page, PageMut, PAGE_DATA_SIZE, PAGE_SIZE};
+pub use root::{RootPage, RootPageMut};
+pub use slotted_page::{SlottedPage, SlottedPageMut, CELL_POINTER_SIZE};

--- a/src/page/manager.rs
+++ b/src/page/manager.rs
@@ -1,4 +1,4 @@
-use super::page::{Page, RO, RW};
+use super::page::{Page, PageMut};
 use crate::snapshot::SnapshotId;
 use std::fmt::Debug;
 pub mod mmap;
@@ -25,17 +25,17 @@ pub enum PageError {
 /// Core trait that manages pages in trie db.
 pub trait PageManager: Debug {
     /// Retrieves a page from the given snapshot.
-    fn get<'p>(&self, snapshot_id: SnapshotId, page_id: PageId) -> Result<Page<'p, RO>, PageError>;
+    fn get<'p>(&self, snapshot_id: SnapshotId, page_id: PageId) -> Result<Page<'p>, PageError>;
 
     /// Retrieves a mutable page from the given snapshot.
     fn get_mut<'p>(
         &mut self,
         snapshot_id: SnapshotId,
         page_id: PageId,
-    ) -> Result<Page<'p, RW>, PageError>;
+    ) -> Result<PageMut<'p>, PageError>;
 
     /// Allocates a new page in the given snapshot.
-    fn allocate<'p>(&mut self, snapshot_id: SnapshotId) -> Result<Page<'p, RW>, PageError>;
+    fn allocate<'p>(&mut self, snapshot_id: SnapshotId) -> Result<PageMut<'p>, PageError>;
 
     /// Resizes the page manager to the given number of pages.
     fn resize(&mut self, new_page_count: PageId) -> Result<(), PageError>;

--- a/src/page/page.rs
+++ b/src/page/page.rs
@@ -1,71 +1,88 @@
-use sealed::sealed;
-
 use crate::{page::PageId, snapshot::SnapshotId};
+use std::{fmt, mem, ops::Deref};
 
 pub const PAGE_SIZE: usize = 4096;
 pub const HEADER_SIZE: usize = 8;
 pub const PAGE_DATA_SIZE: usize = PAGE_SIZE - HEADER_SIZE;
 
-#[sealed]
-pub trait PageKind {}
+#[derive(Copy, Clone)]
+pub struct Page<'p> {
+    id: PageId,
+    data: &'p [u8; PAGE_SIZE],
+    snapshot_id: SnapshotId,
+}
 
-#[derive(Debug)]
-pub struct RO {}
-
-#[sealed]
-impl PageKind for RO {}
-
-#[derive(Debug)]
-pub struct RW {}
-
-#[sealed]
-impl PageKind for RW {}
-
-#[derive(Debug)]
-pub struct Page<'p, P: PageKind> {
+pub struct PageMut<'p> {
+    #[allow(dead_code)]
     id: PageId,
     data: &'p mut [u8; PAGE_SIZE],
     snapshot_id: SnapshotId,
-    _marker: std::marker::PhantomData<P>,
 }
 
-impl<P: PageKind> Page<'_, P> {
-    pub fn page_id(&self) -> PageId {
+// Compile-time assertion to verify that `Page` and `PageMut` have the same layout and internal
+// structure (and consequently that `PageMut` can be safely transmuted to `Page`).
+const _: () = {
+    use std::{alloc::Layout, mem::offset_of};
+
+    let ref_layout = Layout::new::<Page<'_>>();
+    let mut_layout = Layout::new::<PageMut<'_>>();
+    assert!(ref_layout.size() == mut_layout.size());
+    assert!(ref_layout.align() == mut_layout.align());
+
+    assert!(offset_of!(Page<'_>, id) == offset_of!(PageMut<'_>, id));
+    assert!(offset_of!(Page<'_>, data) == offset_of!(PageMut<'_>, data));
+    assert!(offset_of!(Page<'_>, snapshot_id) == offset_of!(PageMut<'_>, snapshot_id));
+};
+
+fn fmt_page(name: &str, p: &Page<'_>, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.debug_struct(name)
+        .field("id", &p.id())
+        .field("data", &"[...]")
+        .field("snapshot_id", &p.snapshot_id())
+        .finish()
+}
+
+impl<'p> Page<'p> {
+    pub fn new(id: PageId, data: &'p [u8; PAGE_SIZE]) -> Self {
+        let snapshot_id = u64::from_le_bytes(data[0..8].try_into().unwrap());
+        Self { id, snapshot_id, data }
+    }
+
+    pub fn id(&self) -> PageId {
         self.id
     }
 
-    // Returns the snapshot id of the page.
+    /// Returns the snapshot id of the page.
     pub fn snapshot_id(&self) -> SnapshotId {
         self.snapshot_id
     }
 
-    // Returns the contents of the page without the header
+    /// Returns the contents of the page without the header
     pub fn contents(&self) -> &[u8] {
         &self.data[HEADER_SIZE..]
     }
 }
 
-impl<'p> Page<'p, RO> {
-    pub fn new_ro(id: PageId, data: &'p mut [u8; PAGE_SIZE]) -> Self {
-        let snapshot_id = u64::from_le_bytes(data[0..8].try_into().unwrap());
-        Self { id, snapshot_id, data, _marker: std::marker::PhantomData }
+impl fmt::Debug for Page<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_page("Page", self, f)
     }
 }
 
-impl<'p> Page<'p, RW> {
-    pub fn new_rw(id: PageId, data: &'p mut [u8; PAGE_SIZE]) -> Self {
+impl<'p> PageMut<'p> {
+    pub fn new(id: PageId, data: &'p mut [u8; PAGE_SIZE]) -> Self {
         let snapshot_id = u64::from_le_bytes(data[0..8].try_into().unwrap());
-        Self { id, snapshot_id, data, _marker: std::marker::PhantomData }
+        Self { id, snapshot_id, data }
     }
 
-    // Creates a new RW Page with the given id, snapshot id, and data.
-    pub fn new_rw_with_snapshot(
+    /// Creates a new RW Page with the given id, snapshot id, and data.
+    pub fn with_snapshot(
         id: PageId,
         snapshot_id: SnapshotId,
         data: &'p mut [u8; PAGE_SIZE],
     ) -> Self {
         data[0..8].copy_from_slice(&snapshot_id.to_le_bytes());
-        Self { id, snapshot_id, data, _marker: std::marker::PhantomData }
+        Self { id, snapshot_id, data }
     }
 
     pub fn set_snapshot_id(&mut self, snapshot_id: SnapshotId) {
@@ -73,15 +90,26 @@ impl<'p> Page<'p, RW> {
         self.data[0..8].copy_from_slice(&snapshot_id.to_le_bytes());
     }
 
-    // Returns a mutable reference to the contents of the page without the header
+    /// Returns a mutable reference to the contents of the page without the header
     pub fn contents_mut(&mut self) -> &mut [u8] {
         &mut self.data[HEADER_SIZE..]
     }
 }
 
-impl<'p> From<Page<'p, RW>> for Page<'p, RO> {
-    fn from(page: Page<'p, RW>) -> Self {
-        Self::new_ro(page.id, page.data)
+impl<'p> Deref for PageMut<'p> {
+    type Target = Page<'p>;
+
+    fn deref(&self) -> &Page<'p> {
+        // SAFETY: `Page` and `PageMut` have the same layout and representation. This transmutation
+        // has the only effect of downcasting a mutable reference to an immutable reference, which
+        // is safe.
+        unsafe { mem::transmute(self) }
+    }
+}
+
+impl fmt::Debug for PageMut<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_page("PageMut", &*self, f)
     }
 }
 
@@ -90,25 +118,39 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_page_mut_clone() {
-        let page_id = 42;
-        let snapshot_id = 1337;
-
+    fn test_ref_new() {
+        let id = 42;
         let mut data = [0; PAGE_SIZE];
-        let mut page_mut = Page::new_rw_with_snapshot(page_id, snapshot_id, &mut data);
-        assert_eq!(page_mut.page_id(), page_id);
-        assert_eq!(page_mut.snapshot_id(), snapshot_id);
-        assert_eq!(page_mut.contents()[0], 0);
 
-        page_mut.contents_mut()[0] = 1;
-        assert_eq!(page_mut.contents_mut()[0], 1);
-        assert_eq!(page_mut.contents()[0], 1);
+        let page = Page::new(id, &mut data);
 
-        let page = Page::<'_, RO>::from(page_mut);
-        assert_eq!(page.page_id(), page_id);
-        assert_eq!(page.snapshot_id(), snapshot_id);
-        assert_eq!(page.contents()[0], 1);
+        assert_eq!(page.id(), 42);
+        assert_eq!(page.snapshot_id(), 0);
+        assert_eq!(page.contents(), [0u8; PAGE_DATA_SIZE]);
+    }
 
-        assert_eq!(data[HEADER_SIZE], 1);
+    #[test]
+    fn test_mut_new() {
+        let id = 42;
+        let mut data = [0; PAGE_SIZE];
+
+        let page_mut = PageMut::new(id, &mut data);
+
+        assert_eq!(page_mut.id(), 42);
+        assert_eq!(page_mut.snapshot_id(), 0);
+        assert_eq!(page_mut.contents(), [0u8; PAGE_DATA_SIZE]);
+    }
+
+    #[test]
+    fn test_mut_with_snapshot() {
+        let id = 42;
+        let snapshot = 1337;
+        let mut data = [0; PAGE_SIZE];
+
+        let page_mut = PageMut::with_snapshot(id, snapshot, &mut data);
+
+        assert_eq!(page_mut.id(), 42);
+        assert_eq!(page_mut.snapshot_id(), 1337);
+        assert_eq!(page_mut.contents(), [0u8; PAGE_DATA_SIZE]);
     }
 }

--- a/src/page/slotted_page.rs
+++ b/src/page/slotted_page.rs
@@ -1,10 +1,9 @@
-use std::cmp::{max, Ordering};
-
+use super::{Page, PageError, PageMut, PAGE_DATA_SIZE};
 use crate::storage::value::{Value, ValueRef};
-
-use super::{
-    page::{PageKind, RO, RW},
-    Page, PageError, PageId, PAGE_DATA_SIZE,
+use std::{
+    cmp::{max, Ordering},
+    fmt, mem,
+    ops::Deref,
 };
 
 pub mod cell_pointer;
@@ -16,15 +15,24 @@ pub const CELL_POINTER_SIZE: usize = 3;
 // A page that contains a sequence of pointers to variable-length values,
 // where the pointers are stored in a contiguous array of 3-byte cell pointers from the
 // beginning of the page, and the values are added from the end of the page.
-pub struct SlottedPage<'p, P: PageKind> {
-    page: Page<'p, P>,
+#[repr(transparent)]
+#[derive(Copy, Clone)]
+pub struct SlottedPage<'p> {
+    page: Page<'p>,
 }
 
-impl<P: PageKind> SlottedPage<'_, P> {
-    pub fn page_id(&self) -> PageId {
-        self.page.page_id()
-    }
+fn fmt_slotted_page(name: &str, p: &SlottedPage<'_>, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    let num_cells = p.num_cells();
+    f.debug_struct(name)
+        .field("id", &p.id())
+        .field("num_cells", &num_cells)
+        .field("cell_pointers", &p.cell_pointers_iter().collect::<Vec<_>>())
+        .field("free_bytes", &p.num_free_bytes_with_cell_count(num_cells))
+        .field("dead_bytes", &p.num_dead_bytes(num_cells))
+        .finish()
+}
 
+impl SlottedPage<'_> {
     // Get a reference to a value
     pub fn get_value_ref<'v, V: ValueRef<'v>>(&'v self, index: u8) -> Result<V, PageError> {
         let cell_pointer = self.get_cell_pointer(index)?;
@@ -102,20 +110,39 @@ impl<P: PageKind> SlottedPage<'_, P> {
     }
 }
 
-impl<P: PageKind> std::fmt::Debug for SlottedPage<'_, P> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let num_cells = self.num_cells();
-        write!(f, "SlottedPage {{ page_id: {}, num_cells: {}, cell_pointers: {:?}, free_bytes: {}, dead_bytes: {} }}",
-            self.page_id(),
-            self.num_cells(),
-            self.cell_pointers_iter().collect::<Vec<CellPointer>>(),
-            self.num_free_bytes_with_cell_count(num_cells),
-            self.num_dead_bytes(num_cells)
-        )
+impl<'p> Deref for SlottedPage<'p> {
+    type Target = Page<'p>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.page
     }
 }
 
-impl SlottedPage<'_, RW> {
+impl<'p> From<SlottedPage<'p>> for Page<'p> {
+    fn from(slotted_page: SlottedPage<'p>) -> Self {
+        slotted_page.page
+    }
+}
+
+impl<'p> TryFrom<Page<'p>> for SlottedPage<'p> {
+    type Error = PageError;
+
+    fn try_from(page: Page<'p>) -> Result<Self, Self::Error> {
+        Ok(Self { page })
+    }
+}
+
+impl fmt::Debug for SlottedPage<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_slotted_page("SlottedPage", self, f)
+    }
+}
+
+pub struct SlottedPageMut<'p> {
+    page: PageMut<'p>,
+}
+
+impl SlottedPageMut<'_> {
     // Sets the value at the given index.
     pub fn set_value<V: Value>(&mut self, index: u8, value: &V) -> Result<(), PageError> {
         let cell_pointer = self.get_cell_pointer(index)?;
@@ -365,23 +392,33 @@ impl SlottedPage<'_, RW> {
     }
 }
 
-impl<'p, P: PageKind> From<SlottedPage<'p, P>> for Page<'p, P> {
-    fn from(page: SlottedPage<'p, P>) -> Self {
-        page.page
+impl<'p> Deref for SlottedPageMut<'p> {
+    type Target = SlottedPage<'p>;
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: `SlottedPage` uses `repr(transparent)`, thus `SlottedPage` and `Page` have the
+        // same layout.
+        unsafe { mem::transmute(&*self.page) }
     }
 }
 
-impl<'p> From<SlottedPage<'p, RW>> for SlottedPage<'p, RO> {
-    fn from(page: SlottedPage<'p, RW>) -> Self {
-        Self { page: page.page.into() }
+impl<'p> From<SlottedPageMut<'p>> for PageMut<'p> {
+    fn from(slotted_page: SlottedPageMut<'p>) -> Self {
+        slotted_page.page
     }
 }
 
-impl<'p, P: PageKind> TryFrom<Page<'p, P>> for SlottedPage<'p, P> {
+impl<'p> TryFrom<PageMut<'p>> for SlottedPageMut<'p> {
     type Error = PageError;
 
-    fn try_from(page: Page<'p, P>) -> Result<Self, Self::Error> {
+    fn try_from(page: PageMut<'p>) -> Result<Self, Self::Error> {
         Ok(Self { page })
+    }
+}
+
+impl fmt::Debug for SlottedPageMut<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_slotted_page("SlottedPageMut", &*self, f)
     }
 }
 
@@ -394,8 +431,8 @@ mod tests {
     #[test]
     fn test_insert_get_value() {
         let mut data = [0; PAGE_SIZE];
-        let page = Page::new_rw_with_snapshot(42, 123, &mut data);
-        let mut subtrie_page = SlottedPage::<RW>::try_from(page).unwrap();
+        let page = PageMut::with_snapshot(42, 123, &mut data);
+        let mut subtrie_page = SlottedPageMut::try_from(page).unwrap();
 
         let v1 = String::from("hello");
         let i1 = subtrie_page.insert_value(&v1).unwrap();
@@ -422,8 +459,8 @@ mod tests {
     #[test]
     fn test_insert_set_value() {
         let mut data = [0; PAGE_SIZE];
-        let page = Page::new_rw_with_snapshot(42, 123, &mut data);
-        let mut subtrie_page = SlottedPage::<RW>::try_from(page).unwrap();
+        let page = PageMut::with_snapshot(42, 123, &mut data);
+        let mut subtrie_page = SlottedPageMut::try_from(page).unwrap();
 
         let v1 = String::from("hello");
         let i1 = subtrie_page.insert_value(&v1).unwrap();
@@ -442,8 +479,8 @@ mod tests {
     #[test]
     fn test_set_value_same_length() {
         let mut data = [0; PAGE_SIZE];
-        let page = Page::new_rw_with_snapshot(42, 123, &mut data);
-        let mut subtrie_page = SlottedPage::<RW>::try_from(page).unwrap();
+        let page = PageMut::with_snapshot(42, 123, &mut data);
+        let mut subtrie_page = SlottedPageMut::try_from(page).unwrap();
 
         let v1 = String::from("hello");
         let i1 = subtrie_page.insert_value(&v1).unwrap();
@@ -472,8 +509,8 @@ mod tests {
     #[test]
     fn test_set_value_shrink() {
         let mut data = [0; PAGE_SIZE];
-        let page = Page::new_rw_with_snapshot(42, 123, &mut data);
-        let mut subtrie_page = SlottedPage::<RW>::try_from(page).unwrap();
+        let page = PageMut::with_snapshot(42, 123, &mut data);
+        let mut subtrie_page = SlottedPageMut::try_from(page).unwrap();
 
         let v1 = String::from("hello");
         let i1 = subtrie_page.insert_value(&v1).unwrap();
@@ -504,8 +541,8 @@ mod tests {
     #[test]
     fn test_set_value_shrink_with_neighbors() {
         let mut data = [0; PAGE_SIZE];
-        let page = Page::new_rw_with_snapshot(42, 123, &mut data);
-        let mut subtrie_page = SlottedPage::<RW>::try_from(page).unwrap();
+        let page = PageMut::with_snapshot(42, 123, &mut data);
+        let mut subtrie_page = SlottedPageMut::try_from(page).unwrap();
 
         let v1 = String::from("one");
         let i1 = subtrie_page.insert_value(&v1).unwrap();
@@ -564,8 +601,8 @@ mod tests {
     #[test]
     fn test_set_value_grow() {
         let mut data = [0; PAGE_SIZE];
-        let page = Page::new_rw_with_snapshot(42, 123, &mut data);
-        let mut subtrie_page = SlottedPage::<RW>::try_from(page).unwrap();
+        let page = PageMut::with_snapshot(42, 123, &mut data);
+        let mut subtrie_page = SlottedPageMut::try_from(page).unwrap();
 
         let v1 = String::from("this");
         let i1 = subtrie_page.insert_value(&v1).unwrap();
@@ -594,8 +631,8 @@ mod tests {
     #[test]
     fn test_set_value_grow_with_neighbors() {
         let mut data = [0; PAGE_SIZE];
-        let page = Page::new_rw_with_snapshot(42, 123, &mut data);
-        let mut subtrie_page = SlottedPage::<RW>::try_from(page).unwrap();
+        let page = PageMut::with_snapshot(42, 123, &mut data);
+        let mut subtrie_page = SlottedPageMut::try_from(page).unwrap();
 
         let v1 = String::from("one");
         let i1 = subtrie_page.insert_value(&v1).unwrap();
@@ -654,8 +691,8 @@ mod tests {
     #[test]
     fn test_allocate_get_delete_cell_pointer() {
         let mut data = [0; PAGE_SIZE];
-        let page = Page::new_rw_with_snapshot(42, 123, &mut data);
-        let mut subtrie_page = SlottedPage::<RW>::try_from(page).unwrap();
+        let page = PageMut::with_snapshot(42, 123, &mut data);
+        let mut subtrie_page = SlottedPageMut::try_from(page).unwrap();
         let cell_index = subtrie_page.insert_value(&String::from("foo")).unwrap();
         assert_eq!(cell_index, 0);
         assert_eq!(subtrie_page.num_cells(), 1);
@@ -747,8 +784,8 @@ mod tests {
     #[test]
     fn test_allocate_reuse_deleted_space() {
         let mut data = [0; PAGE_SIZE];
-        let page = Page::new_rw_with_snapshot(42, 123, &mut data);
-        let mut subtrie_page = SlottedPage::<RW>::try_from(page).unwrap();
+        let page = PageMut::with_snapshot(42, 123, &mut data);
+        let mut subtrie_page = SlottedPageMut::try_from(page).unwrap();
 
         let i0 = subtrie_page.insert_value(&String::from_iter(&['a'; 1020])).unwrap();
         assert_eq!(i0, 0);
@@ -776,8 +813,8 @@ mod tests {
     #[test]
     fn test_allocate_reuse_deleted_spaces() {
         let mut data = [0; PAGE_SIZE];
-        let page = Page::new_rw_with_snapshot(42, 123, &mut data);
-        let mut subtrie_page = SlottedPage::<RW>::try_from(page).unwrap();
+        let page = PageMut::with_snapshot(42, 123, &mut data);
+        let mut subtrie_page = SlottedPageMut::try_from(page).unwrap();
 
         // bytes 0-12 are used by the header, and the next 4072 are used by the first 4 cells
         // this sums up to 4085 bytes, which allows for one more pointer to be added later
@@ -834,8 +871,8 @@ mod tests {
     #[test]
     fn test_defragment_page() {
         let mut data = [0; PAGE_SIZE];
-        let page = Page::new_rw_with_snapshot(42, 123, &mut data);
-        let mut subtrie_page = SlottedPage::<RW>::try_from(page).unwrap();
+        let page = PageMut::with_snapshot(42, 123, &mut data);
+        let mut subtrie_page = SlottedPageMut::try_from(page).unwrap();
 
         let i0 = subtrie_page.insert_value(&String::from_iter(&['a'; 814])).unwrap();
         assert_eq!(i0, 0);
@@ -880,8 +917,8 @@ mod tests {
     #[test]
     fn test_defragment_page_cells_out_of_order() {
         let mut data = [0; PAGE_SIZE];
-        let page = Page::new_rw_with_snapshot(42, 123, &mut data);
-        let mut slotted_page = SlottedPage::<RW>::try_from(page).unwrap();
+        let page = PageMut::with_snapshot(42, 123, &mut data);
+        let mut slotted_page = SlottedPageMut::try_from(page).unwrap();
 
         slotted_page.set_num_cells(16);
 

--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -4,8 +4,8 @@ use crate::{
     location::Location,
     node::{Node, TrieValue},
     page::{
-        OrphanPageManager, Page, PageError, PageId, PageManager, RootPage, SlottedPage,
-        CELL_POINTER_SIZE, PAGE_DATA_SIZE, RO, RW,
+        OrphanPageManager, Page, PageError, PageId, PageManager, PageMut, RootPageMut, SlottedPage,
+        SlottedPageMut, CELL_POINTER_SIZE, PAGE_DATA_SIZE,
     },
     path::{AddressPath, StoragePath, ADDRESS_PATH_LENGTH, STORAGE_PATH_LENGTH},
     pointer::Pointer,
@@ -56,7 +56,7 @@ impl<P: PageManager> StorageEngine<P> {
     /// Allocates a new page from the underlying page manager.
     /// If there is an orphaned page available as of the given [SnapshotId],
     /// it is used to allocate a new page instead.
-    fn allocate_page<'p>(&self, context: &mut TransactionContext) -> Result<Page<'p, RW>, Error> {
+    fn allocate_page<'p>(&self, context: &mut TransactionContext) -> Result<PageMut<'p>, Error> {
         self.inner.write().unwrap().allocate_page(context)
     }
 
@@ -67,7 +67,7 @@ impl<P: PageManager> StorageEngine<P> {
         &self,
         context: &mut TransactionContext,
         page_id: PageId,
-    ) -> Result<Page<'p, RW>, Error> {
+    ) -> Result<PageMut<'p>, Error> {
         let mut inner = self.inner.write().unwrap();
         let original_page = inner.get_page_mut(context, page_id)?;
 
@@ -88,7 +88,7 @@ impl<P: PageManager> StorageEngine<P> {
         &self,
         context: &TransactionContext,
         page_id: PageId,
-    ) -> Result<Page<'p, RO>, Error> {
+    ) -> Result<Page<'p>, Error> {
         self.inner.read().unwrap().get_page(context, page_id)
     }
 
@@ -98,7 +98,7 @@ impl<P: PageManager> StorageEngine<P> {
         &self,
         context: &TransactionContext,
         page_id: PageId,
-    ) -> Result<Page<'p, RW>, Error> {
+    ) -> Result<PageMut<'p>, Error> {
         self.inner.write().unwrap().get_page_mut(context, page_id)
     }
 
@@ -194,7 +194,7 @@ impl<P: PageManager> StorageEngine<P> {
         context: &TransactionContext,
         original_path: &Nibbles,
         path_offset: usize,
-        slotted_page: SlottedPage<'_, RO>,
+        slotted_page: SlottedPage<'_>,
         page_index: u8,
     ) -> Result<Option<TrieValue>, Error> {
         let node: Node = slotted_page.get_value(page_index)?;
@@ -214,7 +214,7 @@ impl<P: PageManager> StorageEngine<P> {
                 {
                     context
                         .contract_account_loc_cache
-                        .insert(original_path.clone(), (slotted_page.page_id(), page_index));
+                        .insert(original_path.clone(), (slotted_page.id(), page_index));
                 }
             }
 
@@ -269,7 +269,7 @@ impl<P: PageManager> StorageEngine<P> {
         if context.metadata.root_subtrie_page_id == 0 {
             // Handle empty trie case, inserting the first new value before traversing the trie.
             let page = self.allocate_page(context)?;
-            let mut slotted_page = SlottedPage::try_from(page)?;
+            let mut slotted_page = SlottedPageMut::try_from(page)?;
             let ((path, value), remaining_changes) = changes.split_first_mut().unwrap();
             let value = value.as_ref().expect("unable to delete from empty trie");
             let root_pointer = self.handle_empty_trie(context, path, value, &mut slotted_page)?;
@@ -310,7 +310,7 @@ impl<P: PageManager> StorageEngine<P> {
         page_id: PageId,
     ) -> Result<Option<Pointer>, Error> {
         let page = self.get_mut_clone(context, page_id)?;
-        let mut new_slotted_page = SlottedPage::try_from(page)?;
+        let mut new_slotted_page = SlottedPageMut::try_from(page)?;
         let mut split_count = 0;
 
         loop {
@@ -382,7 +382,7 @@ impl<P: PageManager> StorageEngine<P> {
         context: &mut TransactionContext,
         changes: &[(Nibbles, Option<TrieValue>)],
         path_offset: u8,
-        slotted_page: &mut SlottedPage<'_, RW>,
+        slotted_page: &mut SlottedPageMut<'_>,
         page_index: u8,
     ) -> Result<Option<Pointer>, Error> {
         let mut node = slotted_page.get_value::<Node>(page_index)?;
@@ -391,7 +391,7 @@ impl<P: PageManager> StorageEngine<P> {
             // no changes to make. just return a pointer to ourself.
             let rlp_node = node.rlp_encode();
             return Ok(Some(Pointer::new(
-                self.node_location(slotted_page.page_id(), page_index),
+                self.node_location(slotted_page.id(), page_index),
                 rlp_node,
             )));
         }
@@ -491,7 +491,7 @@ impl<P: PageManager> StorageEngine<P> {
         _context: &mut TransactionContext,
         path: &Nibbles,
         value: &TrieValue,
-        slotted_page: &mut SlottedPage<'_, RW>,
+        slotted_page: &mut SlottedPageMut<'_>,
     ) -> Result<Pointer, Error> {
         let new_node = Node::new_leaf(path.clone(), value);
         let rlp_node = new_node.rlp_encode();
@@ -499,7 +499,7 @@ impl<P: PageManager> StorageEngine<P> {
         let index = slotted_page.insert_value(&new_node)?;
         assert_eq!(index, 0, "root node must be at index 0");
 
-        Ok(Pointer::new(Location::for_page(slotted_page.page_id()), rlp_node))
+        Ok(Pointer::new(Location::for_page(slotted_page.id()), rlp_node))
     }
 
     /// Handles the case when the path does not match the node prefix
@@ -508,7 +508,7 @@ impl<P: PageManager> StorageEngine<P> {
         context: &mut TransactionContext,
         changes: &[(Nibbles, Option<TrieValue>)],
         path_offset: u8,
-        slotted_page: &mut SlottedPage<'_, RW>,
+        slotted_page: &mut SlottedPageMut<'_>,
         page_index: u8,
         node: &mut Node,
         common_prefix: Nibbles,
@@ -544,7 +544,7 @@ impl<P: PageManager> StorageEngine<P> {
         context: &mut TransactionContext,
         changes: &[(Nibbles, Option<TrieValue>)],
         path_offset: u8,
-        slotted_page: &mut SlottedPage<'_, RW>,
+        slotted_page: &mut SlottedPageMut<'_>,
         page_index: u8,
         node: &mut Node,
         path: Nibbles,
@@ -597,7 +597,7 @@ impl<P: PageManager> StorageEngine<P> {
         let (_, remaining_changes) = changes.split_first().unwrap();
 
         if remaining_changes.is_empty() {
-            Ok(Some(Pointer::new(self.node_location(slotted_page.page_id(), page_index), rlp_node)))
+            Ok(Some(Pointer::new(self.node_location(slotted_page.id(), page_index), rlp_node)))
         } else {
             // Recurse with changes to the right
             self.set_values_in_cloned_page(
@@ -616,7 +616,7 @@ impl<P: PageManager> StorageEngine<P> {
         context: &mut TransactionContext,
         changes: &[(Nibbles, Option<TrieValue>)],
         path_offset: u8,
-        slotted_page: &mut SlottedPage<'_, RW>,
+        slotted_page: &mut SlottedPageMut<'_>,
         page_index: u8,
         node: &mut Node,
         common_prefix_length: usize,
@@ -637,10 +637,7 @@ impl<P: PageManager> StorageEngine<P> {
                 self.update_node_child(node, slotted_page, page_index, new_child_pointer, 0)?;
 
                 let rlp_node = node.rlp_encode();
-                Ok(Some(Pointer::new(
-                    self.node_location(slotted_page.page_id(), page_index),
-                    rlp_node,
-                )))
+                Ok(Some(Pointer::new(self.node_location(slotted_page.id(), page_index), rlp_node)))
             } else {
                 // Handle remote child node (on different page)
                 let child_page_id = child_pointer.location().page_id().unwrap();
@@ -654,10 +651,7 @@ impl<P: PageManager> StorageEngine<P> {
                 self.update_node_child(node, slotted_page, page_index, new_child_pointer, 0)?;
 
                 let rlp_node = node.rlp_encode();
-                Ok(Some(Pointer::new(
-                    self.node_location(slotted_page.page_id(), page_index),
-                    rlp_node,
-                )))
+                Ok(Some(Pointer::new(self.node_location(slotted_page.id(), page_index), rlp_node)))
             }
         } else {
             // The account has no storage trie yet, create a new leaf node for the first slot
@@ -679,7 +673,7 @@ impl<P: PageManager> StorageEngine<P> {
         context: &mut TransactionContext,
         changes: &[(Nibbles, Option<TrieValue>)],
         path_offset: u8,
-        slotted_page: &mut SlottedPage<'_, RW>,
+        slotted_page: &mut SlottedPageMut<'_>,
         page_index: u8,
         node: &mut Node,
         common_prefix_length: usize,
@@ -688,7 +682,7 @@ impl<P: PageManager> StorageEngine<P> {
             // there are no changes to make. just return a pointer to our current node.
             let rlp_node = node.rlp_encode();
             return Ok(Some(Pointer::new(
-                self.node_location(slotted_page.page_id(), page_index),
+                self.node_location(slotted_page.id(), page_index),
                 rlp_node,
             )));
         }
@@ -731,7 +725,7 @@ impl<P: PageManager> StorageEngine<P> {
 
         if changes.is_empty() {
             return Ok(Some(Pointer::new(
-                self.node_location(slotted_page.page_id(), page_index),
+                self.node_location(slotted_page.id(), page_index),
                 rlp_node,
             )));
         }
@@ -744,7 +738,7 @@ impl<P: PageManager> StorageEngine<P> {
     fn update_node_child(
         &self,
         node: &mut Node,
-        slotted_page: &mut SlottedPage<'_, RW>,
+        slotted_page: &mut SlottedPageMut<'_>,
         page_index: u8,
         new_child_pointer: Option<Pointer>,
         child_index: u8,
@@ -765,7 +759,7 @@ impl<P: PageManager> StorageEngine<P> {
         context: &mut TransactionContext,
         changes: &[(Nibbles, Option<TrieValue>)],
         path_offset: u8,
-        slotted_page: &mut SlottedPage<'_, RW>,
+        slotted_page: &mut SlottedPageMut<'_>,
         page_index: u8,
         node: &mut Node,
         common_prefix_length: usize,
@@ -905,7 +899,7 @@ impl<P: PageManager> StorageEngine<P> {
     fn handle_branch_node_cleanup(
         &self,
         context: &mut TransactionContext,
-        slotted_page: &mut SlottedPage<'_, RW>,
+        slotted_page: &mut SlottedPageMut<'_>,
         page_index: u8,
         node: &Node,
     ) -> Result<Option<Pointer>, Error> {
@@ -929,7 +923,7 @@ impl<P: PageManager> StorageEngine<P> {
             // Normal branch node with multiple children
             let rlp_node = node.rlp_encode();
             return Ok(Some(Pointer::new(
-                self.node_location(slotted_page.page_id(), page_index),
+                self.node_location(slotted_page.id(), page_index),
                 rlp_node,
             )));
         }
@@ -939,7 +933,7 @@ impl<P: PageManager> StorageEngine<P> {
     fn merge_branch_with_only_child(
         &self,
         context: &mut TransactionContext,
-        slotted_page: &mut SlottedPage<'_, RW>,
+        slotted_page: &mut SlottedPageMut<'_>,
         page_index: u8,
         node: &Node,
         only_child_index: u8,
@@ -956,7 +950,7 @@ impl<P: PageManager> StorageEngine<P> {
                     context,
                     only_child_node_pointer.location().page_id().expect("page_id should exist"),
                 )?;
-                let child_slotted_page = SlottedPage::try_from(child_page)?;
+                let child_slotted_page = SlottedPageMut::try_from(child_page)?;
                 (child_slotted_page.get_value(0)?, Some(child_slotted_page))
             };
 
@@ -996,7 +990,7 @@ impl<P: PageManager> StorageEngine<P> {
     /// Handles merging a branch with a child on the same page
     fn merge_with_child_on_same_page(
         &self,
-        slotted_page: &mut SlottedPage<'_, RW>,
+        slotted_page: &mut SlottedPageMut<'_>,
         page_index: u8,
         only_child_node: Node,
         only_child_node_pointer: &Pointer,
@@ -1017,7 +1011,7 @@ impl<P: PageManager> StorageEngine<P> {
         }
 
         Ok(Some(Pointer::new(
-            self.node_location(slotted_page.page_id(), only_child_node_index),
+            self.node_location(slotted_page.id(), only_child_node_index),
             rlp_node,
         )))
     }
@@ -1026,13 +1020,13 @@ impl<P: PageManager> StorageEngine<P> {
     fn merge_with_child_on_different_page(
         &self,
         context: &mut TransactionContext,
-        slotted_page: &mut SlottedPage<'_, RW>,
+        slotted_page: &mut SlottedPageMut<'_>,
         page_index: u8,
         only_child_node: Node,
-        mut child_slotted_page: SlottedPage<'_, RW>,
+        mut child_slotted_page: SlottedPageMut<'_>,
         rlp_node: alloy_trie::nodes::RlpNode,
     ) -> Result<Option<Pointer>, Error> {
-        let branch_page_id = slotted_page.page_id();
+        let branch_page_id = slotted_page.id();
 
         // Ensure the child page has enough space
         if child_slotted_page.num_free_bytes() < 200 {
@@ -1053,7 +1047,7 @@ impl<P: PageManager> StorageEngine<P> {
                 .add_orphaned_page_id(context.metadata.snapshot_id, branch_page_id);
         }
 
-        Ok(Some(Pointer::new(self.node_location(child_slotted_page.page_id(), 0), rlp_node)))
+        Ok(Some(Pointer::new(self.node_location(child_slotted_page.id(), 0), rlp_node)))
     }
 
     fn node_location(&self, page_id: PageId, page_index: u8) -> Location {
@@ -1069,11 +1063,11 @@ impl<P: PageManager> StorageEngine<P> {
     fn split_page(
         &self,
         context: &mut TransactionContext,
-        page: &mut SlottedPage<'_, RW>,
+        page: &mut SlottedPageMut<'_>,
     ) -> Result<(), Error> {
         while page.num_free_bytes() < PAGE_DATA_SIZE / 4_usize {
             let child_page = self.allocate_page(context)?;
-            let mut child_slotted_page = SlottedPage::try_from(child_page)?;
+            let mut child_slotted_page = SlottedPageMut::try_from(child_page)?;
 
             let mut root_node: Node = page.get_value(0)?;
 
@@ -1103,7 +1097,7 @@ impl<P: PageManager> StorageEngine<P> {
                 root_node.set_child(
                     largest_child_index,
                     Pointer::new(
-                        Location::for_page(child_slotted_page.page_id()),
+                        Location::for_page(child_slotted_page.id()),
                         largest_child_pointer.rlp().clone(),
                     ),
                 );
@@ -1117,9 +1111,9 @@ impl<P: PageManager> StorageEngine<P> {
     // Helper function to move an entire subtrie from one page to another.
     fn move_subtrie_nodes(
         &self,
-        source_page: &mut SlottedPage<'_, RW>,
+        source_page: &mut SlottedPageMut<'_>,
         root_index: u8,
-        target_page: &mut SlottedPage<'_, RW>,
+        target_page: &mut SlottedPageMut<'_>,
     ) -> Result<Location, Error> {
         let node: Node = source_page.get_value(root_index)?;
         source_page.delete_value(root_index)?;
@@ -1131,7 +1125,7 @@ impl<P: PageManager> StorageEngine<P> {
 
         // if the node has no children, we're done.
         if !has_children {
-            return Ok(self.node_location(target_page.page_id(), new_index));
+            return Ok(self.node_location(target_page.id(), new_index));
         }
 
         // otherwise, we need to move the children of the node.
@@ -1168,7 +1162,7 @@ impl<P: PageManager> StorageEngine<P> {
         // update the parent node with the new child pointers.
         target_page.set_value(new_index, &updated_node)?;
 
-        Ok(self.node_location(target_page.page_id(), new_index))
+        Ok(self.node_location(target_page.id(), new_index))
     }
 
     // Recursively deletes a subtrie from the page, orphaning any pages that become fully
@@ -1176,7 +1170,7 @@ impl<P: PageManager> StorageEngine<P> {
     fn delete_subtrie(
         &self,
         context: &mut TransactionContext,
-        slotted_page: &mut SlottedPage<'_, RW>,
+        slotted_page: &mut SlottedPageMut<'_>,
         cell_index: u8,
     ) -> Result<(), Error> {
         if cell_index == 0 {
@@ -1184,7 +1178,7 @@ impl<P: PageManager> StorageEngine<P> {
             // all of our descendant pages. Instead of deleting each cell one-by-one
             // we can orphan our entire page, and recursively orphan all our descendant
             // pages as well.
-            return self.orphan_subtrie(context, slotted_page.page_id());
+            return self.orphan_subtrie(context, slotted_page.id());
         }
 
         let node: Node = slotted_page.get_value(cell_index)?;
@@ -1234,7 +1228,7 @@ impl<P: PageManager> StorageEngine<P> {
     fn orphan_subtrie_helper(
         &self,
         context: &mut TransactionContext,
-        slotted_page: &SlottedPage<'_, RO>,
+        slotted_page: &SlottedPage<'_>,
         cell_index: u8,
         orphan_page_ids: &mut Vec<PageId>,
     ) -> Result<(), Error> {
@@ -1261,7 +1255,7 @@ impl<P: PageManager> StorageEngine<P> {
         }
 
         if cell_index == 0 {
-            orphan_page_ids.push(slotted_page.page_id());
+            orphan_page_ids.push(slotted_page.id());
         }
 
         Ok(())
@@ -1365,7 +1359,7 @@ fn find_shortest_common_prefix<T>(
 }
 
 // Helper function to count nodes in a subtrie on the given page
-fn count_subtrie_nodes(page: &SlottedPage<'_, RW>, root_index: u8) -> Result<u8, Error> {
+fn count_subtrie_nodes(page: &SlottedPage<'_>, root_index: u8) -> Result<u8, Error> {
     let mut count = 1; // Count the root node
     let node: Node = page.get_value(root_index)?;
     if !node.has_children() {
@@ -1386,22 +1380,22 @@ impl<P: PageManager> Inner<P> {
     fn allocate_page<'p>(
         &mut self,
         context: &mut TransactionContext,
-    ) -> Result<Page<'p, RW>, Error> {
+    ) -> Result<PageMut<'p>, Error> {
         let orphaned_page_id = self.orphan_manager.get_orphaned_page_id();
-        let page_to_return: Page<'p, RW>;
-        if let Some(orphaned_page_id) = orphaned_page_id {
+        let page_to_return = if let Some(orphaned_page_id) = orphaned_page_id {
             let mut page = self.get_page_mut(context, orphaned_page_id)?;
             page.set_snapshot_id(context.metadata.snapshot_id);
             page.contents_mut().fill(0);
             context.transaction_metrics.inc_pages_reallocated();
-            page_to_return = page;
+            page
         } else {
-            page_to_return = self.page_manager.allocate(context.metadata.snapshot_id)?;
+            let page = self.page_manager.allocate(context.metadata.snapshot_id)?;
             context.transaction_metrics.inc_pages_allocated();
-        }
+            page
+        };
 
         context.metadata.max_page_number =
-            max(context.metadata.max_page_number, page_to_return.page_id());
+            max(context.metadata.max_page_number, page_to_return.id());
         Ok(page_to_return)
     }
 
@@ -1420,7 +1414,7 @@ impl<P: PageManager> Inner<P> {
             .unwrap();
         page_mut.set_snapshot_id(context.metadata.snapshot_id);
         // TODO: include the remaining metadata in the new root page.
-        let mut new_root_page = RootPage::new(
+        let mut new_root_page = RootPageMut::new(
             page_mut,
             context.metadata.state_root,
             context.metadata.root_subtrie_page_id,
@@ -1448,7 +1442,7 @@ impl<P: PageManager> Inner<P> {
         &mut self,
         context: &TransactionContext,
         page_id: PageId,
-    ) -> Result<Page<'p, RW>, Error> {
+    ) -> Result<PageMut<'p>, Error> {
         let page = self.page_manager.get_mut(context.metadata.snapshot_id, page_id)?;
         context.transaction_metrics.inc_pages_read();
         Ok(page)
@@ -1459,7 +1453,7 @@ impl<P: PageManager> Inner<P> {
         &self,
         context: &TransactionContext,
         page_id: PageId,
-    ) -> Result<Page<'p, RO>, Error> {
+    ) -> Result<Page<'p>, Error> {
         let page = self.page_manager.get(context.metadata.snapshot_id, page_id)?;
         context.transaction_metrics.inc_pages_read();
         Ok(page)
@@ -1555,7 +1549,7 @@ mod tests {
 
         // Initial allocation
         let mut page = storage_engine.allocate_page(&mut context).unwrap();
-        assert_eq!(page.page_id(), 256);
+        assert_eq!(page.id(), 256);
         assert_eq!(page.contents()[0], 0);
         assert_eq!(page.snapshot_id(), 1);
         assert_metrics(&context, 0, 1, 0, 0);
@@ -1568,23 +1562,23 @@ mod tests {
 
         // reading mutated page
         let page = storage_engine.get_page(&context, 256).unwrap();
-        assert_eq!(page.page_id(), 256);
+        assert_eq!(page.id(), 256);
         assert_eq!(page.contents()[0], 123);
         assert_eq!(page.snapshot_id(), 1);
         assert_metrics(&context, 1, 0, 0, 0);
 
         // cloning a page should allocate a new page and orphan the original page
         let cloned_page = storage_engine.get_mut_clone(&mut context, 256).unwrap();
-        assert_eq!(cloned_page.page_id(), 257);
+        assert_eq!(cloned_page.id(), 257);
         assert_eq!(cloned_page.contents()[0], 123);
         assert_eq!(cloned_page.snapshot_id(), 2);
-        assert_ne!(cloned_page.page_id(), page.page_id());
+        assert_ne!(cloned_page.id(), page.id());
         assert_metrics(&context, 2, 1, 0, 0);
 
         // the next allocation should not come from the orphaned page, as the snapshot id is the
         // same as when the page was orphaned
         let page = storage_engine.allocate_page(&mut context).unwrap();
-        assert_eq!(page.page_id(), 258);
+        assert_eq!(page.id(), 258);
         assert_eq!(page.contents()[0], 0);
         assert_eq!(page.snapshot_id(), 2);
         assert_metrics(&context, 2, 2, 0, 0);
@@ -1595,7 +1589,7 @@ mod tests {
         // the next allocation should not come from the orphaned page, as the snapshot has not been
         // unlocked yet
         let page = storage_engine.allocate_page(&mut context).unwrap();
-        assert_eq!(page.page_id(), 259);
+        assert_eq!(page.id(), 259);
         assert_eq!(page.contents()[0], 0);
         assert_eq!(page.snapshot_id(), 3);
         assert_metrics(&context, 0, 1, 0, 0);
@@ -1605,7 +1599,7 @@ mod tests {
         // the next allocation should come from the orphaned page because the snapshot id has
         // increased. The page data should be zeroed out.
         let page = storage_engine.allocate_page(&mut context).unwrap();
-        assert_eq!(page.page_id(), 256);
+        assert_eq!(page.id(), 256);
         assert_eq!(page.contents()[0], 0);
         assert_eq!(page.snapshot_id(), 3);
         assert_metrics(&context, 1, 1, 1, 0);
@@ -2004,7 +1998,7 @@ mod tests {
 
         // Split the page
         let page = storage_engine.get_mut_page(&context, 256).unwrap();
-        let mut slotted_page = SlottedPage::try_from(page).unwrap();
+        let mut slotted_page = SlottedPageMut::try_from(page).unwrap();
         storage_engine.split_page(&mut context, &mut slotted_page).unwrap();
 
         // Verify all accounts still exist after split
@@ -2538,7 +2532,7 @@ mod tests {
             if matches!(page_result, Err(Error::PageError(PageError::PageNotFound(_)))) {
                 break;
             }
-            let mut slotted_page = SlottedPage::try_from(page_result.unwrap()).unwrap();
+            let mut slotted_page = SlottedPageMut::try_from(page_result.unwrap()).unwrap();
 
             // Try to split this page
             if storage_engine.split_page(&mut context, &mut slotted_page).is_ok() {
@@ -2663,7 +2657,7 @@ mod tests {
 
             // Try to get and split the page
             if let Ok(page) = storage_engine.get_mut_page(&context, page_id) {
-                if let Ok(mut slotted_page) = SlottedPage::try_from(page) {
+                if let Ok(mut slotted_page) = SlottedPageMut::try_from(page) {
                     // Force a split
                     let _ = storage_engine.split_page(&mut context, &mut slotted_page);
 
@@ -3254,15 +3248,15 @@ mod tests {
         // page1 will hold our root node and the branch node
         let page1 =
             storage_engine.get_mut_page(&context, context.metadata.root_subtrie_page_id).unwrap();
-        let mut slotted_page1 = SlottedPage::try_from(page1).unwrap();
+        let mut slotted_page1 = SlottedPageMut::try_from(page1).unwrap();
 
         // page2 will hold our 1st child
         let page2 = storage_engine.allocate_page(&mut context).unwrap();
-        let mut slotted_page2 = SlottedPage::try_from(page2).unwrap();
+        let mut slotted_page2 = SlottedPageMut::try_from(page2).unwrap();
 
         // page3 will hold our 2nd child
         let page3 = storage_engine.allocate_page(&mut context).unwrap();
-        let mut slotted_page3 = SlottedPage::try_from(page3).unwrap();
+        let mut slotted_page3 = SlottedPageMut::try_from(page3).unwrap();
 
         // we will force add 2 children to this branch node
         let mut child_1_full_path = [0u8; 64];
@@ -3289,11 +3283,11 @@ mod tests {
 
         // child 1 is the root of page2
         slotted_page2.insert_value(&child_1).unwrap();
-        let child_1_location = Location::from(slotted_page2.page_id());
+        let child_1_location = Location::from(slotted_page2.id());
 
         // child 2 is the root of page3
         slotted_page3.insert_value(&child_2).unwrap();
-        let child_2_location = Location::from(slotted_page3.page_id());
+        let child_2_location = Location::from(slotted_page3.id());
 
         let mut new_branch_node: Node = Node::new_branch(Nibbles::new());
         new_branch_node.set_child(0, Pointer::new(child_1_location, RlpNode::default()));
@@ -3330,7 +3324,7 @@ mod tests {
         assert!(root_node.is_branch());
         let child_2_pointer = root_node.child(5).unwrap();
         assert!(child_2_pointer.location().page_id().is_some());
-        assert_eq!(child_2_pointer.location().page_id().unwrap(), slotted_page3.page_id());
+        assert_eq!(child_2_pointer.location().page_id().unwrap(), slotted_page3.id());
 
         // check that the prefix for child 2 has changed
         let child_2_node: Node = slotted_page3.get_value(0).unwrap();
@@ -3357,11 +3351,11 @@ mod tests {
 
         // page2 will hold our 1st child
         let page2 = storage_engine.allocate_page(&mut context).unwrap();
-        let mut slotted_page2 = SlottedPage::try_from(page2).unwrap();
+        let mut slotted_page2 = SlottedPageMut::try_from(page2).unwrap();
 
         // page3 will hold our 2nd child
         let page3 = storage_engine.allocate_page(&mut context).unwrap();
-        let mut slotted_page3 = SlottedPage::try_from(page3).unwrap();
+        let mut slotted_page3 = SlottedPageMut::try_from(page3).unwrap();
 
         // we will force add 2 children to our root node
         let mut child_1_full_path = [0u8; 64];
@@ -3386,11 +3380,11 @@ mod tests {
 
         // child 1 is the root of page2
         slotted_page2.insert_value(&child_1).unwrap();
-        let child_1_location = Location::from(slotted_page2.page_id());
+        let child_1_location = Location::from(slotted_page2.id());
 
         // child 2 is the root of page3
         slotted_page3.insert_value(&child_2).unwrap();
-        let child_2_location = Location::from(slotted_page3.page_id());
+        let child_2_location = Location::from(slotted_page3.id());
 
         // next we create and update our root node
         let mut root_node = Node::new_branch(Nibbles::new());
@@ -3398,8 +3392,8 @@ mod tests {
         root_node.set_child(15, Pointer::new(child_2_location, RlpNode::default()));
 
         let root_node_page = storage_engine.allocate_page(&mut context).unwrap();
-        context.metadata.root_subtrie_page_id = root_node_page.page_id();
-        let mut slotted_page = SlottedPage::try_from(root_node_page).unwrap();
+        context.metadata.root_subtrie_page_id = root_node_page.id();
+        let mut slotted_page = SlottedPageMut::try_from(root_node_page).unwrap();
         let root_index = slotted_page.insert_value(&root_node).unwrap();
         assert_eq!(root_index, 0);
 
@@ -3433,7 +3427,7 @@ mod tests {
         let root_node_slotted = SlottedPage::try_from(root_node_page).unwrap();
         let root_node: Node = root_node_slotted.get_value(0).unwrap();
         assert!(!root_node.is_branch());
-        assert_eq!(root_node_slotted.page_id(), child_2_location.page_id().unwrap());
+        assert_eq!(root_node_slotted.id(), child_2_location.page_id().unwrap());
 
         // check that the prefix for root node has changed
         assert_eq!(root_node.prefix().clone(), child_2_nibbles);


### PR DESCRIPTION
This is a prerequiste PR for simplifying the work of synchronizing access to pages across threads.

The main rationale behind this change is that to avoid undefined behavior, and enforce Rust's memory safety rules, we need a type that has `data: &'p [u8; PAGE_SIZE]` and one that has `data: &'p mut [u8; PAGE_SIZE]`. The same could in theory be accomplished with the marker types `RO` and `RW`, but that would be more tricky and not worth the cost to maintain.

This change also makes code less verbose and more in line with Rust conventions.