### PR TITLE
perf: find_shortest_common_prefix in constant time

### DIFF
--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -453,7 +453,7 @@ impl<P: PageManager> StorageEngine<P> {
         if common_prefix_length < node.prefix().len() {
             if value.is_none() {
                 let (changes_left, changes_right) = changes.split_at(shortest_common_prefix_idx);
-                let changes_right = changes_right.split_first().unwrap().1;
+                let changes_right = &changes_right[1..];
                 if changes_right.is_empty() {
                     return self.set_values_in_cloned_page(
                         context,


### PR DESCRIPTION
Update `find_shortest_common_prefix` to only peek at the first and last element of the changes list, instead of performing a full scan.
Also internally dereferences the paths as `&[u8]` instead of calling `Nibbles.slice`. This avoids copying the data into a new owned slice.

Depends on the fact that the `changes` set must be sorted **and** must only be traversed/sliced via common prefix, such that even after applying a nonzero `prefix_offset`, the matching `changes` set should still be sorted. This is _partially_ checked in a `debug_assert!`