### PR TITLE
Remove the `PageManager` trait

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -1,7 +1,7 @@
 use crate::{
     context::TransactionContext,
     metrics::DatabaseMetrics,
-    page::{MmapPageManager, OrphanPageManager, PageError, PageId, PageManager, RootPage},
+    page::{OrphanPageManager, PageError, PageId, PageManager, RootPage},
     snapshot::SnapshotId,
     storage::engine::{self, StorageEngine},
     transaction::{Transaction, TransactionError, TransactionManager, RO, RW},
@@ -11,15 +11,15 @@ use alloy_trie::EMPTY_ROOT_HASH;
 use std::sync::RwLock;
 
 #[derive(Debug)]
-pub struct Database<P: PageManager> {
-    pub(crate) inner: Inner<P>,
+pub struct Database {
+    pub(crate) inner: Inner,
     metrics: DatabaseMetrics,
 }
 
 #[derive(Debug)]
-pub(crate) struct Inner<P: PageManager> {
+pub(crate) struct Inner {
     pub(crate) metadata: RwLock<Metadata>,
-    pub(crate) storage_engine: RwLock<StorageEngine<P>>,
+    pub(crate) storage_engine: RwLock<StorageEngine>,
     pub(crate) transaction_manager: RwLock<TransactionManager>,
 }
 
@@ -50,10 +50,10 @@ pub enum Error {
     CloseError(engine::Error),
 }
 
-impl Database<MmapPageManager> {
+impl Database {
     pub fn create(file_path: &str) -> Result<Self, Error> {
         // TODO: handle the case where the file already exists.
-        let mut page_manager = MmapPageManager::open(file_path).map_err(Error::PageError)?;
+        let mut page_manager = PageManager::open(file_path).map_err(Error::PageError)?;
         // allocate the first 256 pages for the root, orphans, and root subtrie
         page_manager.resize(1000).map_err(Error::PageError)?;
         for i in 0..256 {
@@ -80,7 +80,7 @@ impl Database<MmapPageManager> {
     }
 
     pub fn open(file_path: &str) -> Result<Self, Error> {
-        let page_manager = MmapPageManager::open(file_path).map_err(Error::PageError)?;
+        let page_manager = PageManager::open(file_path).map_err(Error::PageError)?;
 
         let root_page_0 = page_manager.get(0, 0).map_err(Error::PageError)?;
         let root_page_1 = page_manager.get(0, 1).map_err(Error::PageError)?;
@@ -107,14 +107,14 @@ impl Database<MmapPageManager> {
     }
 }
 
-impl<P: PageManager> Drop for Database<P> {
+impl Drop for Database {
     fn drop(&mut self) {
         self.shrink_and_commit().expect("failed to close database")
     }
 }
 
-impl<P: PageManager> Database<P> {
-    pub fn new(metadata: Metadata, storage_engine: StorageEngine<P>) -> Self {
+impl Database {
+    pub fn new(metadata: Metadata, storage_engine: StorageEngine) -> Self {
         Self {
             inner: Inner {
                 metadata: RwLock::new(metadata),
@@ -125,7 +125,7 @@ impl<P: PageManager> Database<P> {
         }
     }
 
-    pub fn begin_rw(&self) -> Result<Transaction<'_, RW, P>, TransactionError> {
+    pub fn begin_rw(&self) -> Result<Transaction<'_, RW>, TransactionError> {
         let mut transaction_manager = self.inner.transaction_manager.write().unwrap();
         let storage_engine = self.inner.storage_engine.read().unwrap();
         let metadata = self.inner.metadata.read().unwrap().next();
@@ -137,7 +137,7 @@ impl<P: PageManager> Database<P> {
         Ok(Transaction::new(context, self, None))
     }
 
-    pub fn begin_ro(&self) -> Result<Transaction<'_, RO, P>, TransactionError> {
+    pub fn begin_ro(&self) -> Result<Transaction<'_, RO>, TransactionError> {
         let mut transaction_manager = self.inner.transaction_manager.write().unwrap();
         let storage_engine = self.inner.storage_engine.read().unwrap();
         let metadata = self.inner.metadata.read().unwrap().clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,4 +12,4 @@ pub mod storage;
 pub mod transaction;
 
 pub use database::Database;
-pub use page::MmapPageManager;
+pub use page::PageManager;

--- a/src/page.rs
+++ b/src/page.rs
@@ -4,7 +4,7 @@ mod page;
 mod root;
 mod slotted_page;
 
-pub use manager::{mmap::MmapPageManager, PageError, PageId, PageManager};
+pub use manager::{PageError, PageId, PageManager};
 pub use orphan::OrphanPageManager;
 pub use page::{Page, PageMut};
 pub use root::{RootPage, RootPageMut};

--- a/src/page/manager.rs
+++ b/src/page/manager.rs
@@ -1,7 +1,6 @@
-use super::page::{Page, PageMut};
-use crate::snapshot::SnapshotId;
-use std::fmt::Debug;
-pub mod mmap;
+mod mmap;
+
+pub use mmap::PageManager;
 
 /// Type alias for page ids.
 /// Currently we use 4 bytes for page ids, which implies a maximum of 16TB of data.
@@ -21,53 +20,4 @@ pub enum PageError {
     InvalidValue,
     InvalidPageContents(PageId),
     // TODO: add more errors here for other cases.
-}
-
-/// Core trait that manages pages in trie db.
-pub trait PageManager: Debug {
-    /// Retrieves a page from the given snapshot.
-    fn get<'p>(&self, snapshot_id: SnapshotId, page_id: PageId) -> Result<Page<'p>, PageError>;
-
-    /// Retrieves a mutable page from the given snapshot.
-    fn get_mut<'p>(
-        &mut self,
-        snapshot_id: SnapshotId,
-        page_id: PageId,
-    ) -> Result<PageMut<'p>, PageError>;
-
-    /// Allocates a new page in the given snapshot.
-    fn allocate<'p>(&mut self, snapshot_id: SnapshotId) -> Result<PageMut<'p>, PageError>;
-
-    /// Resizes the page manager to the given number of pages.
-    fn resize(&mut self, new_page_count: PageId) -> Result<(), PageError>;
-
-    /// Returns the total number of pages
-    fn size(&self) -> u32;
-
-    // /// Merges two pages into a new page.
-    // fn merge(
-    //     &mut self,
-    //     snapshot_id: SnapshotId,
-    //     page_a: PageId,
-    //     page_b: PageId,
-    //     page_out: PageId,
-    // ) -> Result<(), PageError>;
-
-    // /// Splits a page into two new pages.
-    // fn split(
-    //     &mut self,
-    //     snapshot_id: SnapshotId,
-    //     page_id: PageId,
-    // ) -> Result<(PageId, PageId), PageError>;
-
-    // /// Writes data to a page.
-    // fn write(
-    //     &mut self,
-    //     snapshot_id: SnapshotId,
-    //     page_id: PageId,
-    //     data: &[u8],
-    // ) -> Result<(), PageError>;
-
-    /// Commits pages associated with a snapshot to durable storage.
-    fn commit(&mut self, snapshot_id: SnapshotId) -> Result<(), PageError>;
 }

--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -35,13 +35,13 @@ use super::value::Value;
 ///
 /// All operations are thread-safe through the use of a read-write lock around the inner state.
 #[derive(Debug)]
-pub struct StorageEngine<P: PageManager> {
-    inner: Arc<RwLock<Inner<P>>>,
+pub struct StorageEngine {
+    inner: Arc<RwLock<Inner>>,
 }
 
 #[derive(Debug)]
-struct Inner<P: PageManager> {
-    page_manager: P,
+struct Inner {
+    page_manager: PageManager,
     orphan_manager: OrphanPageManager,
 }
 
@@ -51,9 +51,9 @@ enum PointerChange {
     Delete,
 }
 
-impl<P: PageManager> StorageEngine<P> {
+impl StorageEngine {
     /// Creates a new [StorageEngine] with the given [PageManager] and [OrphanPageManager].
-    pub fn new(page_manager: P, orphan_manager: OrphanPageManager) -> Self {
+    pub fn new(page_manager: PageManager, orphan_manager: OrphanPageManager) -> Self {
         Self { inner: Arc::new(RwLock::new(Inner { page_manager, orphan_manager })) }
     }
 
@@ -1462,7 +1462,7 @@ fn move_subtrie_nodes(
     Ok(node_location(target_page.id(), new_index))
 }
 
-impl<P: PageManager> Inner<P> {
+impl Inner {
     fn allocate_page<'p>(
         &mut self,
         context: &mut TransactionContext,

--- a/src/storage/proofs.rs
+++ b/src/storage/proofs.rs
@@ -6,7 +6,7 @@ use crate::{
         Node::{self, AccountLeaf, Branch},
         TrieValue,
     },
-    page::{PageManager, SlottedPage},
+    page::SlottedPage,
     path::{AddressPath, StoragePath, ADDRESS_PATH_LENGTH},
     pointer::Pointer,
 };
@@ -21,7 +21,7 @@ use super::engine::Error;
 
 use super::engine::StorageEngine;
 
-impl<P: PageManager> StorageEngine<P> {
+impl StorageEngine {
     /// Retrieves a [(Account, MultiProof)] from the storage engine, identified by the given
     /// [AddressPath]. Returns [None] if the path is not found.
     pub fn get_account_with_proof(

--- a/src/storage/test_utils.rs
+++ b/src/storage/test_utils.rs
@@ -6,13 +6,11 @@ pub mod test_utils {
 
     use crate::{
         account::Account, context::TransactionContext, database::Metadata, page::OrphanPageManager,
-        storage::engine::StorageEngine, MmapPageManager,
+        storage::engine::StorageEngine, PageManager,
     };
 
-    pub(crate) fn create_test_engine(
-        page_count: u32,
-    ) -> (StorageEngine<MmapPageManager>, TransactionContext) {
-        let manager = MmapPageManager::new_anon(page_count, 256).unwrap();
+    pub(crate) fn create_test_engine(page_count: u32) -> (StorageEngine, TransactionContext) {
+        let manager = PageManager::new_anon(page_count, 256).unwrap();
         let orphan_manager = OrphanPageManager::new();
         let metadata = Metadata {
             snapshot_id: 1,


### PR DESCRIPTION
And rename the `MmapPageManager` struct to `PageManager`.

Removing the trait makes the code for the entire crate much more compact and easier to read/write. It's unlikely that we will add a new `PageManager` trait implementation, so it's not worth the cost to maintain. And if we ever do want multiple implementations, then we can always add the trait back. Let's increase complexity later when/if we need it.