### PR TITLE
Avoid remapping when the storage needs to grow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tempdir = "0.3.7"
 rand = "0.8.5"
 walkdir = "2"
 serde_json = "1.0.140"
+tempfile = "3.19.1"
 
 [lib]
 bench = false

--- a/src/page.rs
+++ b/src/page.rs
@@ -4,7 +4,7 @@ mod page;
 mod root;
 mod slotted_page;
 
-pub use manager::{PageError, PageId, PageManager};
+pub use manager::{mmap::PageManager, options::PageManagerOptions, PageError, PageId};
 pub use orphan::OrphanPageManager;
 pub use page::{Page, PageMut};
 pub use root::{RootPage, RootPageMut};

--- a/src/page/manager.rs
+++ b/src/page/manager.rs
@@ -1,6 +1,5 @@
-mod mmap;
-
-pub use mmap::PageManager;
+pub(super) mod mmap;
+pub(super) mod options;
 
 /// Type alias for page ids.
 /// Currently we use 4 bytes for page ids, which implies a maximum of 16TB of data.
@@ -11,6 +10,7 @@ pub type PageId = u32;
 pub enum PageError {
     PageNotFound(PageId),
     OutOfBounds(PageId),
+    PageLimitReached,
     InvalidRootPage(PageId),
     InvalidCellPointer,
     NoFreeCells,

--- a/src/page/manager/mmap.rs
+++ b/src/page/manager/mmap.rs
@@ -1,56 +1,114 @@
-use std::{fs::File, path::Path};
-
 use crate::{
-    page::{Page, PageError, PageId, PageMut},
+    page::{Page, PageError, PageId, PageManagerOptions, PageMut},
     snapshot::SnapshotId,
 };
-use memmap2::{Advice, MmapMut};
+use memmap2::{Advice, MmapMut, MmapOptions};
+use std::{fs::File, path::Path};
 
 // Manages pages in a memory mapped file.
 #[derive(Debug)]
 pub struct PageManager {
     mmap: MmapMut,
-    file: Option<File>,
+    file: File,
+    file_len: u64,
     next_page_id: PageId,
 }
 
 impl PageManager {
-    pub fn open(file_path: impl AsRef<Path>) -> Result<Self, PageError> {
-        let file = File::options()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(file_path)
-            .map_err(PageError::IO)?;
+    pub fn options() -> PageManagerOptions {
+        PageManagerOptions::new()
+    }
+
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, PageError> {
+        Self::options().open(path)
+    }
+
+    pub fn from_file(file: File) -> Result<Self, PageError> {
+        Self::options().wrap(file)
+    }
+
+    #[cfg(test)]
+    pub fn open_temp_file() -> Result<Self, PageError> {
+        Self::options().open_temp_file()
+    }
+
+    pub(super) fn open_with_options(
+        opts: &PageManagerOptions,
+        path: impl AsRef<Path>,
+    ) -> Result<Self, PageError> {
+        let file = opts.open_options.open(path).map_err(PageError::IO)?;
+        Self::from_file_with_options(opts, file)
+    }
+
+    pub(super) fn from_file_with_options(
+        opts: &PageManagerOptions,
+        file: File,
+    ) -> Result<Self, PageError> {
+        // Allocate a memory map as large as possible, so that remapping will never be needed. If
+        // `opts.max_page == PageId::MAX == 2 ** 32 - 1` and `Page::SIZE == 2 ** 12 == 4096`, then
+        // we are requesting `2 ** 44` bytes of memory.
+        //
+        // Allocating such a large memory map is does not actually allocate any memory, nor causes
+        // the backing file to grow to match the memory map size. It simply reserves the required
+        // address space.
+        //
+        // This is safe and sound on 64-bit systems:
+        //
+        // - The size of the memory map may be larger than the amount of memory on the system. The
+        //   kernel will take care of loading/unloading pages as needed.
+        // - On systems where the virtual address space is 48 bits, there is room for *at least* 16
+        //   of such contiguous memory maps, which is more than enough for a single process.
+        //
+        // This can fail if:
+        //
+        // - This is running on a 32-bit system (but this should not be supported).
+        // - The process memory is highly fragmented.
+        // - An rlimit is limiting the maximum memory that the process can obtain.
+        // - Many `PageManager` structs are constructed in parallel (this can happen in tests, but
+        //   should not happen in real-world application).
+        //
+        // Note that even if the memory map has a certain size, reading/writing to it still
+        // requires the backing file to be large enough; failure to do so will result in a SIGBUS.
+        let mmap_len = (opts.max_pages as usize) * Page::SIZE;
+
         // SAFETY: we assume that we have full ownership of the file, even though in practice
         // there's no way to guarantee it
-        let mmap = unsafe { MmapMut::map_mut(&file).map_err(PageError::IO)? };
-        Self::new(mmap, Some(file), None)
-    }
-
-    /// Creates a new `PageManager` with the given memory mapped file.
-    pub fn new(
-        mmap: MmapMut,
-        file: Option<File>,
-        next_page_id: Option<PageId>,
-    ) -> Result<Self, PageError> {
-        let max_pages = (mmap.len() / Page::SIZE).try_into().expect("memory map too large");
-        let next_page_id = next_page_id.unwrap_or(max_pages);
-        if next_page_id > max_pages {
-            panic!("`next_page_id` is greater than the number of pages in the memory map");
-        }
-
+        let mmap =
+            unsafe { MmapOptions::new().len(mmap_len).map_mut(&file).map_err(PageError::IO)? };
         mmap.advise(Advice::Random).map_err(PageError::IO)?;
 
-        Ok(Self { mmap, file, next_page_id })
+        let file_len = file.metadata().map_err(PageError::IO)?.len();
+        let min_file_len = (opts.page_count as u64) * (Page::SIZE as u64);
+        assert!(
+            file_len >= min_file_len,
+            "page_count ({}) exceeds the number of pages in the file ({})",
+            opts.page_count,
+            file_len / (Page::SIZE as u64)
+        );
+
+        Ok(Self { mmap, file, file_len, next_page_id: opts.page_count })
     }
 
-    /// Creates a new `PageManager` with an anonymous memory map.
-    #[cfg(test)]
-    pub(crate) fn new_anon(capacity: PageId, next_page_id: PageId) -> Result<Self, PageError> {
-        let mmap = MmapMut::map_anon(capacity as usize * Page::SIZE).map_err(PageError::IO)?;
-        Self::new(mmap, None, Some(next_page_id))
+    /// Returns the number of pages currently stored in the file.
+    pub fn size(&self) -> u32 {
+        self.next_page_id
+    }
+
+    /// Sets the number of pages currently stored in the file.
+    pub fn set_size(&mut self, size: u32) {
+        assert!(size <= self.capacity(), "size ({}) exceeds capacity ({})", size, self.capacity());
+        assert!(
+            size as u64 <= self.file_len / (Page::SIZE as u64),
+            "size ({}) exceeds the number of pages in the file ({})",
+            size,
+            self.file_len / (Page::SIZE as u64)
+        );
+        self.next_page_id = size;
+    }
+
+    /// Returns the maximum number of pages that can be allocated to the file.
+    pub fn capacity(&self) -> u32 {
+        (self.mmap.len() / Page::SIZE).min(u32::MAX as usize) as u32
     }
 
     // Returns a mutable reference to the data of the page with the given id.
@@ -66,9 +124,14 @@ impl PageManager {
     // Allocates a new page in the memory mapped file.
     fn allocate_page_data<'p>(&mut self) -> Result<(PageId, &'p mut [u8; Page::SIZE]), PageError> {
         let page_id = self.next_page_id;
+        let new_len =
+            page_id.checked_add(1).ok_or(PageError::OutOfBounds(page_id))? as usize * Page::SIZE;
 
-        if (page_id + 1) as usize * Page::SIZE > self.mmap.len() {
+        if new_len > self.mmap.len() {
             return Err(PageError::OutOfBounds(page_id));
+        }
+        if new_len as u64 > self.file_len {
+            self.grow()?;
         }
 
         self.next_page_id += 1;
@@ -76,9 +139,26 @@ impl PageManager {
         page_data.fill(0);
         Ok((page_id, page_data))
     }
-}
 
-impl PageManager {
+    /// Grows the size of the underlaying file (if any) to make room for additional pages.
+    ///
+    /// This will increase the file size by a constant factor of 1024, or a relative factor of
+    /// 12.5%, whichever is greater, without exceeding the maximum capacity of the file.
+    ///
+    /// If this `PageManager` is not backed by any file, then this method returns an error.
+    fn grow(&mut self) -> Result<(), PageError> {
+        let cur_len = self.file_len;
+        let increment = (cur_len / 8).max(1024 * Page::SIZE as u64);
+        let new_len = cur_len + increment;
+        let new_len = new_len.min(self.mmap.len() as u64);
+
+        assert!(new_len > cur_len, "reached max capacity");
+
+        self.file.set_len(new_len).map_err(PageError::IO)?;
+        self.file_len = new_len;
+        Ok(())
+    }
+
     /// Retrieves a page from the memory mapped file.
     pub fn get<'p>(
         &self,
@@ -107,59 +187,6 @@ impl PageManager {
         Ok(PageMut::with_snapshot(page_id, snapshot_id, page_data))
     }
 
-    /// Resizes the memory mapped file to the given number of pages.
-    ///
-    /// If the file size is reduced, the file is truncated and the next page is is lowered to match
-    /// the new file size.
-    pub fn resize(&mut self, new_page_count: PageId) -> Result<(), PageError> {
-        // SAFETY: This is currently unsafe, but so was the previous implementation
-        unsafe {
-            let old_len = self.mmap.len();
-            let new_len = (new_page_count as usize) * Page::SIZE;
-
-            if let Some(ref file) = self.file {
-                // MacOS does not support flushing an empty file
-                if old_len > 0 {
-                    self.mmap.flush().map_err(PageError::IO)?;
-                }
-                file.set_len(new_len as u64).map_err(PageError::IO)?;
-            }
-
-            #[cfg(target_os = "linux")]
-            {
-                self.mmap
-                    .remap(new_len, memmap2::RemapOptions::new().may_move(true))
-                    .map_err(PageError::IO)?;
-            }
-
-            #[cfg(not(target_os = "linux"))]
-            {
-                self.mmap = match self.file {
-                    Some(ref file) => MmapMut::map_mut(file).map_err(PageError::IO)?,
-                    None => {
-                        let mut new_map =
-                            memmap2::MmapMut::map_anon(new_len).map_err(PageError::IO)?;
-                        let common = std::cmp::min(old_len, new_len);
-                        new_map[..common].copy_from_slice(&self.mmap[..common]);
-                        new_map
-                    }
-                };
-                self.mmap.advise(Advice::Random).map_err(PageError::IO)?;
-            }
-
-            if new_len < old_len {
-                self.next_page_id = new_page_count;
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Returns the maximum number of pages that may be allocated.
-    pub fn size(&self) -> u32 {
-        (self.mmap.len() / Page::SIZE) as u32
-    }
-
     /// Syncs pages to the backing file.
     pub fn commit(&mut self) -> Result<(), PageError> {
         self.mmap.flush().map_err(PageError::IO)
@@ -169,11 +196,10 @@ impl PageManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write;
 
     #[test]
     fn test_allocate_get() {
-        let mut manager = PageManager::new_anon(10, 0).unwrap();
+        let mut manager = PageManager::options().max_pages(10).open_temp_file().unwrap();
 
         for i in 0..10 {
             let err = manager.get(42, i).unwrap_err();
@@ -196,7 +222,7 @@ mod tests {
 
     #[test]
     fn test_allocate_get_mut() {
-        let mut manager = PageManager::new_anon(10, 0).unwrap();
+        let mut manager = PageManager::open_temp_file().unwrap();
 
         let mut page = manager.allocate(42).unwrap();
         assert_eq!(page.id(), 0);
@@ -235,135 +261,112 @@ mod tests {
     }
 
     #[test]
-    fn test_resize_file() {
-        // remove the existing file if it already exists
-        let _ = std::fs::remove_file("test.mmap");
+    fn auto_growth() {
+        let snapshot = 123;
 
-        let mut manager = PageManager::open("test.mmap").unwrap();
-        assert_eq!(manager.next_page_id, 0);
+        let f = tempfile::tempfile().expect("temporary file creation failed");
+        let mut m = PageManager::from_file(f.try_clone().unwrap()).expect("mmap creation failed");
 
-        // attempt to allocate, expect error because the file is empty
-        let err = manager.allocate(42).unwrap_err();
-        assert!(matches!(err, PageError::OutOfBounds(0)));
+        fn len(f: &File) -> usize {
+            f.metadata().expect("fetching file metadata failed").len().try_into().unwrap()
+        }
 
-        manager.resize(1).unwrap();
-        assert_eq!(manager.next_page_id, 0);
+        // No page has been allocated; file should be empty
+        assert_eq!(len(&f), 0);
 
-        let mut page = manager.allocate(42).unwrap();
+        // Allocate a page; verify that the size of the file grew by `1024 * Page::SIZE` (the
+        // minimum growth factor)
 
-        assert_eq!(page.id(), 0);
-        assert_eq!(page.contents(), &mut [0; Page::DATA_SIZE]);
-        assert_eq!(page.snapshot_id(), 42);
-        assert_eq!(manager.next_page_id, 1);
+        // For the first 8 * 1024 pages, the automatic growth should be of a constant factor of
+        // `1024 * Page::SIZE`
+        for i in 0..8 {
+            for j in 0..1024 {
+                let p = m.allocate(snapshot).expect("page allocation failed");
+                assert_eq!(p.id() as usize, i * 1024 + j);
+                assert_eq!(len(&f), (i + 1) * 1024 * Page::SIZE);
+            }
+        }
 
-        // write some data to the page
-        page.contents_mut().write_all(b"abc").expect("write failed");
-        manager.commit().unwrap();
-
-        // attempt to allocate again, expect error because the file is full
-        let err = manager.allocate(42).unwrap_err();
-        assert!(matches!(err, PageError::OutOfBounds(1)));
-
-        // resize so that there's room for a new page
-        manager.resize(2).unwrap();
-        assert_eq!(manager.next_page_id, 1);
-
-        // verify that the previous page contents were preserved
-        let page = manager.get(42, 0).unwrap();
-        assert_eq!(page.id(), 0);
-        let mut expected_contents = [0; Page::DATA_SIZE];
-        (&mut expected_contents[..]).write_all(b"abc").expect("write failed");
-        assert_eq!(page.contents(), &expected_contents);
-        assert_eq!(page.snapshot_id(), 42);
-        assert_eq!(manager.next_page_id, 1);
-
-        // verify that there's a new empty page
-        let page = manager.allocate(42).unwrap();
-        assert_eq!(page.id(), 1);
-        assert_eq!(page.contents(), &mut [0; Page::DATA_SIZE]);
-        assert_eq!(page.snapshot_id(), 42);
-        assert_eq!(manager.next_page_id, 2);
-
-        manager.commit().unwrap();
-
-        // attempt to allocate again, expect error because the file is full
-        let err = manager.allocate(42).unwrap_err();
-        assert!(matches!(err, PageError::OutOfBounds(2)));
-
-        let file = manager.file.as_ref().unwrap();
-        let metadata = file.metadata().unwrap();
-        assert_eq!(metadata.len(), 2 * Page::SIZE as u64);
-
-        manager.resize(1).unwrap();
-        assert_eq!(manager.next_page_id, 1);
-
-        let file = manager.file.as_ref().unwrap();
-        let metadata = file.metadata().unwrap();
-        assert_eq!(metadata.len(), Page::SIZE as u64);
-
-        let err = manager.allocate(42).unwrap_err();
-        assert!(matches!(err, PageError::OutOfBounds(1)));
-
-        manager.resize(10).unwrap();
-        assert_eq!(manager.next_page_id, 1);
-
-        let file = manager.file.as_ref().unwrap();
-        let metadata = file.metadata().unwrap();
-        assert_eq!(metadata.len(), 10 * Page::SIZE as u64);
-
-        let page = manager.allocate(42).unwrap();
-        assert_eq!(page.id(), 1);
-        assert_eq!(page.contents(), &mut [0; Page::DATA_SIZE]);
-        assert_eq!(page.snapshot_id(), 42);
-        assert_eq!(manager.next_page_id, 2);
-
-        // clean up
-        let _ = std::fs::remove_file("test.mmap");
+        // From this point on, the automatic growth should be 12.5% (1/8).
+        for id in (8 * 1024)..(9 * 1024) {
+            let p = m.allocate(snapshot).expect("page allocation failed");
+            assert_eq!(p.id(), id);
+            assert_eq!(len(&f), 9 * 1024 * Page::SIZE);
+        }
+        for id in (9 * 1024)..10368 {
+            let p = m.allocate(snapshot).expect("page allocation failed");
+            assert_eq!(p.id(), id);
+            assert_eq!(len(&f), 10368 * Page::SIZE);
+        }
+        for id in 10368..11664 {
+            let p = m.allocate(snapshot).expect("page allocation failed");
+            assert_eq!(p.id(), id);
+            assert_eq!(len(&f), 11664 * Page::SIZE);
+        }
     }
 
     #[test]
-    fn test_resize_anon() {
-        let mut manager = PageManager::new_anon(10, 0).unwrap();
+    fn persistence() {
+        let snapshot = 123;
 
-        // allocate 10 times
-        for i in 0..10 {
-            let mut page = manager.allocate(42).unwrap();
-            assert_eq!(page.id(), i);
-            assert_eq!(page.contents(), &[0; Page::DATA_SIZE]);
-            assert_eq!(page.snapshot_id(), 42);
-            assert_eq!(manager.next_page_id, i + 1);
-            write!(page.contents_mut(), "this is page #{i}").expect("write failed");
+        let f = tempfile::tempfile().expect("temporary file creation failed");
+        let mut m = PageManager::from_file(f.try_clone().unwrap()).expect("mmap creation failed");
+
+        fn len(f: &File) -> usize {
+            f.metadata().expect("fetching file metadata failed").len().try_into().unwrap()
         }
 
-        // attempt to allocate, expect error
-        let err = manager.allocate(42).unwrap_err();
-        assert!(matches!(err, PageError::OutOfBounds(10)));
-
-        // resize to 20
-        manager.resize(20).unwrap();
-
-        // verify the contents of the first 10 pages
-        for i in 0..10 {
-            let page = manager.get(42, i).unwrap();
-            assert_eq!(page.id(), i);
-            assert_eq!(page.snapshot_id(), 42);
-
-            let mut expected_contents = [0; Page::DATA_SIZE];
-            write!(&mut expected_contents[..], "this is page #{i}").expect("write failed");
-            assert_eq!(page.contents(), &expected_contents);
+        fn read(mut f: &File, n: usize) -> Vec<u8> {
+            use std::io::Read;
+            let mut buf = vec![0; n];
+            f.read_exact(&mut buf).expect("read failed");
+            buf
         }
 
-        // allocate 10 more times
-        for i in 10..20 {
-            let page = manager.allocate(42).unwrap();
-            assert_eq!(page.id(), i);
-            assert_eq!(page.contents(), &[0; Page::DATA_SIZE]);
-            assert_eq!(page.snapshot_id(), 42);
-            assert_eq!(manager.next_page_id, i + 1);
+        fn rewind(mut f: &File) {
+            use std::io::Seek;
+            f.rewind().expect("rewind failed");
         }
 
-        // attempt to allocate, expect error
-        let err = manager.allocate(42).unwrap_err();
-        assert!(matches!(err, PageError::OutOfBounds(20)));
+        // No page has been allocated; file should be empty
+        assert_eq!(len(&f), 0);
+
+        // Allocate a page; verify that the size of the file grew by `1024 * Page::SIZE` (the
+        // minimum growth factor) and that the file contents are as expected
+        let mut p = m.allocate(snapshot).expect("page allocation failed");
+        m.commit().expect("commit failed");
+        assert_eq!(len(&f), 1024 * Page::SIZE);
+        assert_eq!(read(&f, 8), snapshot.to_le_bytes());
+        assert_eq!(read(&f, Page::DATA_SIZE), [0; Page::DATA_SIZE]);
+        assert_eq!(read(&f, 1023 * Page::DATA_SIZE), [0; 1023 * Page::DATA_SIZE]);
+        rewind(&f);
+
+        // Write some data to the page
+        p.contents_mut().iter_mut().for_each(|byte| *byte = 0xab);
+        m.commit().expect("commit failed");
+        assert_eq!(len(&f), 1024 * Page::SIZE);
+        assert_eq!(read(&f, 8), snapshot.to_le_bytes());
+        assert_eq!(read(&f, Page::DATA_SIZE), [0xab; Page::DATA_SIZE]);
+        assert_eq!(read(&f, 1023 * Page::DATA_SIZE), [0; 1023 * Page::DATA_SIZE]);
+        rewind(&f);
+
+        // Repeat the test with more pages
+        for new_page_id in 1..=255 {
+            let mut p = m.allocate(snapshot).expect("page allocation failed");
+            p.contents_mut().iter_mut().for_each(|byte| *byte = 0xab ^ (new_page_id as u8));
+            m.commit().expect("commit failed");
+
+            assert_eq!(len(&f), 1024 * Page::SIZE);
+
+            for stored_page_id in 0..=new_page_id {
+                assert_eq!(read(&f, 8), snapshot.to_le_bytes());
+                assert_eq!(
+                    read(&f, Page::DATA_SIZE),
+                    [0xab ^ (stored_page_id as u8); Page::DATA_SIZE]
+                );
+            }
+
+            rewind(&f);
+        }
     }
 }

--- a/src/page/manager/options.rs
+++ b/src/page/manager/options.rs
@@ -1,0 +1,88 @@
+use crate::page::{PageError, PageId, PageManager};
+use std::{
+    fs::{File, OpenOptions},
+    path::Path,
+};
+
+#[derive(Clone, Debug)]
+pub struct PageManagerOptions {
+    pub(super) open_options: OpenOptions,
+    pub(super) page_count: PageId,
+    pub(super) max_pages: PageId,
+}
+
+impl PageManagerOptions {
+    pub fn new() -> Self {
+        let mut open_options = File::options();
+        open_options.read(true).write(true).create(true).truncate(false);
+
+        let max_pages = if cfg!(not(test)) {
+            PageId::MAX
+        } else {
+            // Because tests run in parallel, it's easy to exhaust the address space, so use a more
+            // conservative limit
+            PageId::MAX / 1024
+        };
+
+        Self { open_options, page_count: 0, max_pages }
+    }
+
+    /// Sets the option to create a new file, or open it if it already exists.
+    ///
+    /// The default is `true`.
+    pub fn create(&mut self, create: bool) -> &mut Self {
+        self.open_options.create(create);
+        self
+    }
+
+    /// Sets the option to create a new file, failing if it already exists.
+    ///
+    /// The default is `false`.
+    ///
+    /// If `.create_new(true)` is set, then `.create()` is ignored.
+    pub fn create_new(&mut self, create_new: bool) -> &mut Self {
+        self.open_options.create_new(create_new);
+        self
+    }
+
+    /// Sets the number of pages already written to the file.
+    ///
+    /// The default is `0`.
+    pub fn page_count(&mut self, page_count: PageId) -> &mut Self {
+        self.page_count = page_count;
+        self
+    }
+
+    /// Sets the maximum number of pages that can be allocated to this file.
+    ///
+    /// The default is [`PageId::MAX`].
+    pub fn max_pages(&mut self, max_pages: PageId) -> &mut Self {
+        self.max_pages = max_pages;
+        self
+    }
+
+    /// Opens the file at `path` with the options specified by `self`.
+    pub fn open(&self, path: impl AsRef<Path>) -> Result<PageManager, PageError> {
+        PageManager::open_with_options(self, path)
+    }
+
+    /// Wraps the given `file` with the options specified by `self`.
+    ///
+    /// If `.wrap()` is called, `.create()` and `.create_new()` are ignored.
+    pub fn wrap(&self, file: File) -> Result<PageManager, PageError> {
+        PageManager::from_file_with_options(self, file)
+    }
+
+    /// Opens a temporary file with the options specified by `self`.
+    #[cfg(test)]
+    pub fn open_temp_file(&self) -> Result<PageManager, PageError> {
+        let file = tempfile::tempfile().map_err(PageError::IO)?;
+        self.wrap(file)
+    }
+}
+
+impl Default for PageManagerOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/page/root.rs
+++ b/src/page/root.rs
@@ -327,7 +327,7 @@ mod tests {
     #[test]
     fn test_add_get_orphan_page_ids() {
         // GIVEN: a root page with orphan ids
-        let mut page_manager = PageManager::new_anon(20, 0).unwrap();
+        let mut page_manager = PageManager::open_temp_file().unwrap();
         let page = page_manager.allocate(42).unwrap();
         let mut root_page = RootPageMut::new(page, B256::default(), 0, 0);
         let my_orphan_page_ids: &[PageId] = &[2, 3, 4, 5, 6, 7, 8, 9, 10];
@@ -343,7 +343,7 @@ mod tests {
     #[test]
     fn test_get_empty_orphan_page_ids() {
         // GIVEN: a root page with no orphan ids
-        let mut page_manager = PageManager::new_anon(20, 0).unwrap();
+        let mut page_manager = PageManager::open_temp_file().unwrap();
         let page = page_manager.allocate(42).unwrap();
         let root_page = RootPageMut::new(page, B256::default(), 0, 0);
 
@@ -357,7 +357,7 @@ mod tests {
     #[test]
     fn test_2_page_orphan_page_ids() {
         // GIVEN: a root page with a list of orphan page ids spanning into page 2
-        let mut page_manager = PageManager::new_anon(20, 0).unwrap();
+        let mut page_manager = PageManager::open_temp_file().unwrap();
         let page0 = page_manager.allocate(42).unwrap();
         let _page1 = page_manager.allocate(42).unwrap();
         let mut page2 = page_manager.allocate(42).unwrap();
@@ -399,7 +399,7 @@ mod tests {
     #[test]
     fn test_add_replaces_used_slots() {
         // GIVEN: a root page with a list of orphan page ids
-        let mut page_manager = PageManager::new_anon(20, 0).unwrap();
+        let mut page_manager = PageManager::open_temp_file().unwrap();
         let page = page_manager.allocate(42).unwrap();
         let mut root_page = RootPageMut::new(page, B256::default(), 0, 0);
         let my_orphan_page_ids: &[PageId] = &[1, 2, 3, 4, 5, 6, 7, 8, 9];
@@ -427,7 +427,7 @@ mod tests {
     #[test]
     fn test_add_replaces_used_slots_across_pages() {
         // GIVEN: a root page with a list of orphan page ids spanning 2 pages
-        let mut page_manager = PageManager::new_anon(20, 0).unwrap();
+        let mut page_manager = PageManager::open_temp_file().unwrap();
         let page = page_manager.allocate(42).unwrap();
         let mut root_page = RootPageMut::new(page, B256::default(), 0, 0);
 
@@ -466,7 +466,7 @@ mod tests {
     #[test]
     fn test_add_replaces_used_slots_and_adds_to_end() {
         // GIVEN: a root page with a list of orphan page ids spanning 2 pages
-        let mut page_manager = PageManager::new_anon(20, 0).unwrap();
+        let mut page_manager = PageManager::open_temp_file().unwrap();
         let page = page_manager.allocate(42).unwrap();
         let mut root_page = RootPageMut::new(page, B256::default(), 0, 0);
 
@@ -511,7 +511,7 @@ mod tests {
     #[test]
     fn test_root_0_doesnt_spill_into_root_1() {
         // GIVEN: 2 root pages
-        let mut page_manager = PageManager::new_anon(257, 0).unwrap();
+        let mut page_manager = PageManager::open_temp_file().unwrap();
         let page0 = page_manager.allocate(42).unwrap();
         assert_eq!(page0.id(), 0);
         let mut root_page = RootPageMut::new(page0, B256::default(), 0, 0);
@@ -538,7 +538,7 @@ mod tests {
     #[test]
     fn test_orphan_list_writes_reserved_pages() {
         // GIVEN: 2 root pages with PageId 0 and PageId 1
-        let mut page_manager = PageManager::new_anon(20, 0).unwrap();
+        let mut page_manager = PageManager::open_temp_file().unwrap();
         let page0 = page_manager.allocate(42).unwrap();
         assert_eq!(page0.id(), 0);
         let mut root_page = RootPageMut::new(page0, B256::default(), 0, 0);
@@ -579,7 +579,7 @@ mod tests {
     #[test]
     fn test_orphan_list_allocates_after_reserved_pages() {
         // GIVEN: 256 pages with PageIds [0-255]
-        let mut page_manager = PageManager::new_anon(257, 0).unwrap();
+        let mut page_manager = PageManager::open_temp_file().unwrap();
         let page = page_manager.allocate(42).unwrap();
         assert_eq!(page.id(), 0);
         let mut root_page = RootPageMut::new(page, B256::default(), 0, 0);
@@ -627,7 +627,7 @@ mod tests {
     #[test]
     fn test_orphan_list_shrinks_to_empty() {
         // GIVEN: 256 pages with PageIds [0-255]
-        let mut page_manager = PageManager::new_anon(257, 0).unwrap();
+        let mut page_manager = PageManager::open_temp_file().unwrap();
         let page = page_manager.allocate(42).unwrap();
         assert_eq!(page.id(), 0);
         let mut root_page = RootPageMut::new(page, B256::default(), 0, 0);
@@ -664,7 +664,7 @@ mod tests {
     #[test]
     fn test_vecdeque_rotate_orphan_page_ids() {
         // GIVEN: a root page with orphan ids
-        let mut page_manager = PageManager::new_anon(20, 0).unwrap();
+        let mut page_manager = PageManager::open_temp_file().unwrap();
         let page = page_manager.allocate(42).unwrap();
         let mut root_page = RootPageMut::new(page, B256::default(), 0, 0);
         let my_orphan_page_ids: &[PageId] = &[2, 3, 4, 5, 6, 7, 8, 9, 10];

--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -1381,52 +1381,9 @@ impl StorageEngine {
         Ok(())
     }
 
-    // Ensures that the storage engine has a buffer of at least `min_buffer_size` pages.
-    // This includes unallocated pages at the end of the file, as well as any orphaned pages that
-    // are unlocked. If the buffer is insufficient, the storage engine will be scaled by
-    // `grow_by` until it has at least `min_buffer_size` pages.
-    pub(crate) fn ensure_page_buffer(
-        &mut self,
-        context: &TransactionContext,
-        min_buffer_size: u32,
-        grow_by: f64,
-    ) -> Result<(), Error> {
-        assert!(grow_by > 1.0, "grow_by must be greater than 1.0");
-
-        let current_page_count = self.page_manager.size();
-        let unallocated_page_count = current_page_count - context.metadata.max_page_number - 1;
-        let unlocked_page_count = self.orphan_manager.unlocked_page_count();
-
-        let mut free_page_count = unlocked_page_count + unallocated_page_count;
-
-        if free_page_count < min_buffer_size {
-            let unusable_page_count = current_page_count - free_page_count;
-            let mut new_page_count = current_page_count;
-            while free_page_count < min_buffer_size {
-                new_page_count = (new_page_count as f64 * grow_by) as u32;
-                free_page_count = new_page_count - unusable_page_count;
-            }
-            self.resize(new_page_count)?;
-        }
-
-        Ok(())
-    }
-
     /// Returns the total number of pages in the storage engine.
     pub fn size(&self) -> u32 {
         self.page_manager.size()
-    }
-
-    /// Shrinks the storage to its minimum size and commits all outstanding data to disk.
-    pub fn shrink_and_commit(&mut self, context: &TransactionContext) -> Result<(), Error> {
-        // there will always be a minimum of 256 pages (root pages + reserved orphan pages).
-        let max_page_count = max(context.metadata.max_page_number + 1, 256);
-        // resize the page manager so that we only store the exact amount of pages we need.
-        self.resize(max_page_count)?;
-        // commit all outstanding data to disk.
-        self.commit(context)?;
-
-        Ok(())
     }
 }
 
@@ -1564,13 +1521,6 @@ impl StorageEngine {
         Ok(page_to_return)
     }
 
-    /// Resizes the storage engine to the given number of pages.
-    pub(crate) fn resize(&mut self, new_page_count: PageId) -> Result<(), Error> {
-        self.page_manager.resize(new_page_count)?;
-        Ok(())
-    }
-
-    /// Commits all outstanding data to disk.
     pub fn commit(&mut self, context: &TransactionContext) -> Result<(), Error> {
         // First commit to ensure all changes are written before writing the new root page.
         self.page_manager.commit()?;

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -129,17 +129,6 @@ impl Transaction<'_, RW> {
             self.pending_changes.drain().collect::<Vec<(Nibbles, Option<TrieValue>)>>();
 
         if !changes.is_empty() {
-            // Assume the worst case scenario where each account and storage slot requires a new
-            // page, plus an extra buffer TODO: page buffer and grow_by should be
-            // configurable, but for now 1000 is assumed to be good enough.
-            // It's also possible that we could use a more sophisticated algorithm to estimate the
-            // number of pages required. Note that resizing the current memory-mapped
-            // page manager requires remapping all pages, and cannot be done while any readers are
-            // open.
-            storage_engine
-                .ensure_page_buffer(&self.context, changes.len() as u32 + 1000, 1.2)
-                .unwrap();
-
             storage_engine.set_values(&mut self.context, changes.as_mut()).unwrap();
         }
 


### PR DESCRIPTION
Avoid remapping when the storage needs to grow

The current implementation makes the storage grow or shrink when needed by calling `PageManager::resize()`, which has the effect of changing the backing file size (if any), and resizing the memory map.

Resizing the memory map is particularly problematic because the address of the memory map can change. Therefore:

* `resize()` must be a "stop everything operation";
* on large database, `resize()` may file with out-of-memory errors at runtime;
* `resize()` can have the unintended effect of discarding all the pages cached in memory.

To overcome these problem, this commit changes `PageManager` to create a memory map that spans the entire addressable range, that is: it creates a memory map of size `PageId::MAX * Page::SIZE`. Such a memory map does not need to be ever resized, because it's not possible to have more than `PageId::MAX` pages.

This commit also makes `PageManager` resize the backing file automatically when needed, and removes the `PageManager::resize()` method, removing some redundant logic in `Database`, `StorageEngine`, and `Transaction`. Note that now `PageManager` can only grow automatically, and cannot shrink.