### PR TITLE
Fix most clippy warnings, and run clippy on pull requests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,7 +25,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: rui314/setup-mold@v1
     - uses: dtolnay/rust-toolchain@nightly
       with:
         components: rustfmt
@@ -37,6 +36,14 @@ jobs:
           cargo +nightly fmt --all -- --check
           exit 1
         fi
+
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Lint
+      run: cargo clippy --all-targets -- --deny=warnings
 
   unit-tests:
     strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,15 +8,12 @@ alloy-primitives = { version = "0.8.21", features = ["arbitrary", "rand"] }
 alloy-rlp = "0.3.11"
 alloy-trie = { version = "0.7.6", features = ["arbitrary", "ethereum"] }
 arrayvec = "0.7.6"
-log = "0.4.25"
 memmap2 = "0.9.5"
 proptest = "1.6.0"
 proptest-derive = "0.5.1"
 sealed = "0.6.0"
-pprof = { version = "0.14", features = ["criterion", "protobuf-codec"] }
 metrics-derive = "0.1.0"
 metrics = "0.24.1"
-dashmap = "6.1.0"
 zerocopy = { version = "0.8.24", features = ["derive"] }
 reth-trie-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.2.2" }
 

--- a/benches/benchmark_common.rs
+++ b/benches/benchmark_common.rs
@@ -5,7 +5,7 @@ use tempdir::TempDir;
 use triedb::{
     account::Account,
     path::{AddressPath, StoragePath},
-    Database, MmapPageManager,
+    Database,
 };
 
 pub const BATCH_SIZE: usize = 10_000;
@@ -15,7 +15,7 @@ pub fn generate_random_address(rng: &mut StdRng) -> AddressPath {
     AddressPath::for_address(addr)
 }
 
-pub fn setup_database(size: usize) -> (TempDir, Database<MmapPageManager>) {
+pub fn setup_database(size: usize) -> (TempDir, Database) {
     let dir = TempDir::new("triedb_bench").unwrap();
     let db_path = dir.path().join("db");
     let db = Database::create(db_path.to_str().unwrap()).unwrap();
@@ -38,7 +38,7 @@ pub fn setup_database(size: usize) -> (TempDir, Database<MmapPageManager>) {
     (dir, db)
 }
 
-pub fn setup_database_with_storage(size: usize) -> (TempDir, Database<MmapPageManager>) {
+pub fn setup_database_with_storage(size: usize) -> (TempDir, Database) {
     let dir = TempDir::new("triedb_bench_storage").unwrap();
     let db_path = dir.path().join("db");
     let db = Database::create(db_path.to_str().unwrap()).unwrap();

--- a/benches/proof_benchmarks.rs
+++ b/benches/proof_benchmarks.rs
@@ -1,13 +1,12 @@
 mod benchmark_common;
 
-use alloy_primitives::{StorageKey, U256};
 use benchmark_common::{
     generate_random_address, generate_storage_paths, setup_database, setup_database_with_storage,
     BATCH_SIZE,
 };
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use rand::prelude::*;
-use triedb::path::{AddressPath, StoragePath};
+use triedb::path::AddressPath;
 
 const SIZES: &[usize] = &[1_000_000, 3_000_000];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,14 @@
+#![warn(clippy::dbg_macro)]
+#![warn(clippy::print_stderr)]
+#![warn(clippy::print_stdout)]
+#![warn(missing_debug_implementations)]
+#![warn(unnameable_types)]
+#![warn(unreachable_pub)]
+#![warn(unused_macro_rules)]
+// TODO: temporary allow these warnings so that we can enforce clippy rules
+#![allow(clippy::module_inception)]
+#![allow(clippy::too_many_arguments)]
+
 pub mod account;
 pub mod context;
 pub mod database;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -62,12 +62,12 @@ impl TransactionMetrics {
     }
 
     /// Increment the cache storage read hit
-    pub fn inc_cache_storage_read_hit(&self) {
+    pub(crate) fn inc_cache_storage_read_hit(&self) {
         self.inner.borrow_mut().cache_storage_read_hit += 1;
     }
 
     /// Increment the cache storage read miss
-    pub fn inc_cache_storage_read_miss(&self) {
+    pub(crate) fn inc_cache_storage_read_miss(&self) {
         self.inner.borrow_mut().cache_storage_read_miss += 1;
     }
 
@@ -92,7 +92,7 @@ impl TransactionMetrics {
     }
 
     /// Take the cache storage read hit and miss
-    pub fn take_cache_storage_read(&self) -> (u32, u32) {
+    pub(crate) fn take_cache_storage_read(&self) -> (u32, u32) {
         let mut inner = self.inner.borrow_mut();
         let cache_storage_read_hit = mem::take(&mut inner.cache_storage_read_hit);
         let cache_storage_read_miss = mem::take(&mut inner.cache_storage_read_miss);
@@ -120,7 +120,7 @@ impl TransactionMetrics {
     }
 
     #[cfg(test)]
-    pub fn get_cache_storage_read(&self) -> (u32, u32) {
+    pub(crate) fn get_cache_storage_read(&self) -> (u32, u32) {
         let metrics = self.inner.borrow();
         (metrics.cache_storage_read_hit, metrics.cache_storage_read_miss)
     }

--- a/src/page/manager/mmap.rs
+++ b/src/page/manager/mmap.rs
@@ -49,9 +49,7 @@ impl PageManager {
     /// Creates a new `PageManager` with an anonymous memory map.
     #[cfg(test)]
     pub(crate) fn new_anon(capacity: PageId, next_page_id: PageId) -> Result<Self, PageError> {
-        let mmap = memmap2::MmapMut::map_anon(capacity as usize * Page::SIZE)
-            .map_err(PageError::IO)?
-            .into();
+        let mmap = MmapMut::map_anon(capacity as usize * Page::SIZE).map_err(PageError::IO)?;
         Self::new(mmap, None, Some(next_page_id))
     }
 
@@ -259,7 +257,7 @@ mod tests {
         assert_eq!(manager.next_page_id, 1);
 
         // write some data to the page
-        page.contents_mut().write(b"abc").expect("write failed");
+        page.contents_mut().write_all(b"abc").expect("write failed");
         manager.commit(42).unwrap();
 
         // attempt to allocate again, expect error because the file is full
@@ -274,7 +272,7 @@ mod tests {
         let page = manager.get(42, 0).unwrap();
         assert_eq!(page.id(), 0);
         let mut expected_contents = [0; Page::DATA_SIZE];
-        (&mut expected_contents[..]).write(b"abc").expect("write failed");
+        (&mut expected_contents[..]).write_all(b"abc").expect("write failed");
         assert_eq!(page.contents(), &expected_contents);
         assert_eq!(page.snapshot_id(), 42);
         assert_eq!(manager.next_page_id, 1);

--- a/src/page/slotted_page.rs
+++ b/src/page/slotted_page.rs
@@ -1,13 +1,13 @@
 use super::{Page, PageError, PageMut};
 use crate::storage::value::{Value, ValueRef};
+use cell_pointer::CellPointer;
 use std::{
     cmp::{max, Ordering},
     fmt, mem,
     ops::Deref,
 };
 
-pub mod cell_pointer;
-use cell_pointer::CellPointer;
+pub(crate) mod cell_pointer;
 
 const MAX_NUM_CELLS: u8 = 255; // With 1 byte for the number of cells, the maximum number of cells is 255.
 pub const CELL_POINTER_SIZE: usize = 3;

--- a/src/page/slotted_page/cell_pointer.rs
+++ b/src/page/slotted_page/cell_pointer.rs
@@ -4,7 +4,7 @@ use crate::page::{Page, PageError};
 pub(crate) struct CellPointer<'p>(&'p [u8; 3]);
 
 #[derive(Debug)]
-pub enum CellPointerError {
+pub(crate) enum CellPointerError {
     InvalidLength,
 }
 
@@ -18,7 +18,7 @@ impl From<CellPointerError> for PageError {
 
 impl<'p> CellPointer<'p> {
     // Creates a new cell pointer and writes it to the given data.
-    pub fn new(offset: u16, length: u16, data: &'p mut [u8; 3]) -> Self {
+    pub(crate) fn new(offset: u16, length: u16, data: &'p mut [u8; 3]) -> Self {
         assert!(offset < Page::DATA_SIZE as u16);
         assert!(length < Page::DATA_SIZE as u16);
         assert!(offset >= length);
@@ -30,17 +30,17 @@ impl<'p> CellPointer<'p> {
     }
 
     // Returns the offset of the cell pointer (0-4095), derived from the first 12 bits.
-    pub fn offset(&self) -> u16 {
+    pub(crate) fn offset(&self) -> u16 {
         ((self.0[0] as u16) << 4) | (self.0[1] >> 4) as u16
     }
 
     // Returns the length of the cell pointer, derived from the last 12 bits.
-    pub fn length(&self) -> u16 {
+    pub(crate) fn length(&self) -> u16 {
         ((self.0[1] as u16 & 0b1111) << 8) | self.0[2] as u16
     }
 
     // Returns true if the cell pointer is deleted (all bytes are 0).
-    pub fn is_deleted(&self) -> bool {
+    pub(crate) fn is_deleted(&self) -> bool {
         (self.0[0] | self.0[1] | self.0[2]) == 0
     }
 }

--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -1577,7 +1577,7 @@ mod tests {
         account::Account,
         storage::{
             engine::PageError,
-            test_utils::test_utils::{
+            test_utils::{
                 assert_metrics, create_test_account, create_test_engine, random_test_account,
             },
         },

--- a/src/storage/proofs.rs
+++ b/src/storage/proofs.rs
@@ -309,10 +309,10 @@ impl StorageEngine {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{address, b256, hex, U256};
-    use alloy_trie::{TrieMask, EMPTY_ROOT_HASH, KECCAK_EMPTY};
+    use alloy_trie::{TrieMask, KECCAK_EMPTY};
 
     use super::*;
-    use crate::storage::test_utils::test_utils::{create_test_account, create_test_engine};
+    use crate::storage::test_utils::{create_test_account, create_test_engine};
 
     #[test]
     fn test_get_nonexistent_proof() {

--- a/src/storage/test_utils.rs
+++ b/src/storage/test_utils.rs
@@ -1,62 +1,61 @@
-#[cfg(test)]
-pub mod test_utils {
-    use alloy_primitives::U256;
-    use alloy_trie::{EMPTY_ROOT_HASH, KECCAK_EMPTY};
-    use rand::{rngs::StdRng, RngCore};
+#![cfg(test)]
 
-    use crate::{
-        account::Account, context::TransactionContext, database::Metadata, page::OrphanPageManager,
-        storage::engine::StorageEngine, PageManager,
+use alloy_primitives::U256;
+use alloy_trie::{EMPTY_ROOT_HASH, KECCAK_EMPTY};
+use rand::{rngs::StdRng, RngCore};
+
+use crate::{
+    account::Account, context::TransactionContext, database::Metadata, page::OrphanPageManager,
+    storage::engine::StorageEngine, PageManager,
+};
+
+pub(crate) fn create_test_engine(page_count: u32) -> (StorageEngine, TransactionContext) {
+    let manager = PageManager::new_anon(page_count, 256).unwrap();
+    let orphan_manager = OrphanPageManager::new();
+    let metadata = Metadata {
+        snapshot_id: 1,
+        root_page_id: 0,
+        max_page_number: 255,
+        root_subtrie_page_id: 0,
+        state_root: EMPTY_ROOT_HASH,
     };
+    let storage_engine = StorageEngine::new(manager, orphan_manager);
+    (storage_engine, TransactionContext::new(metadata))
+}
 
-    pub(crate) fn create_test_engine(page_count: u32) -> (StorageEngine, TransactionContext) {
-        let manager = PageManager::new_anon(page_count, 256).unwrap();
-        let orphan_manager = OrphanPageManager::new();
-        let metadata = Metadata {
-            snapshot_id: 1,
-            root_page_id: 0,
-            max_page_number: 255,
-            root_subtrie_page_id: 0,
-            state_root: EMPTY_ROOT_HASH,
-        };
-        let storage_engine = StorageEngine::new(manager, orphan_manager);
-        (storage_engine, TransactionContext::new(metadata))
-    }
+pub(crate) fn random_test_account(rng: &mut StdRng) -> Account {
+    create_test_account(rng.next_u64(), rng.next_u64())
+}
 
-    pub(crate) fn random_test_account(rng: &mut StdRng) -> Account {
-        create_test_account(rng.next_u64(), rng.next_u64())
-    }
+pub(crate) fn create_test_account(balance: u64, nonce: u64) -> Account {
+    Account::new(nonce, U256::from(balance), EMPTY_ROOT_HASH, KECCAK_EMPTY)
+}
 
-    pub(crate) fn create_test_account(balance: u64, nonce: u64) -> Account {
-        Account::new(nonce, U256::from(balance), EMPTY_ROOT_HASH, KECCAK_EMPTY)
-    }
-
-    pub(crate) fn assert_metrics(
-        context: &TransactionContext,
-        pages_read: u32,
-        pages_allocated: u32,
-        pages_reallocated: u32,
-        pages_split: u32,
-    ) {
-        assert_eq!(
-            context.transaction_metrics.get_pages_read(),
-            pages_read,
-            "unexpected number of pages read"
-        );
-        assert_eq!(
-            context.transaction_metrics.get_pages_allocated(),
-            pages_allocated,
-            "unexpected number of pages allocated"
-        );
-        assert_eq!(
-            context.transaction_metrics.get_pages_reallocated(),
-            pages_reallocated,
-            "unexpected number of pages reallocated"
-        );
-        assert_eq!(
-            context.transaction_metrics.get_pages_split(),
-            pages_split,
-            "unexpected number of pages split"
-        );
-    }
+pub(crate) fn assert_metrics(
+    context: &TransactionContext,
+    pages_read: u32,
+    pages_allocated: u32,
+    pages_reallocated: u32,
+    pages_split: u32,
+) {
+    assert_eq!(
+        context.transaction_metrics.get_pages_read(),
+        pages_read,
+        "unexpected number of pages read"
+    );
+    assert_eq!(
+        context.transaction_metrics.get_pages_allocated(),
+        pages_allocated,
+        "unexpected number of pages allocated"
+    );
+    assert_eq!(
+        context.transaction_metrics.get_pages_reallocated(),
+        pages_reallocated,
+        "unexpected number of pages reallocated"
+    );
+    assert_eq!(
+        context.transaction_metrics.get_pages_split(),
+        pages_split,
+        "unexpected number of pages split"
+    );
 }

--- a/tests/ethereum_execution_spec.rs
+++ b/tests/ethereum_execution_spec.rs
@@ -166,8 +166,8 @@ fn run_ethereum_execution_spec_state_tests() {
             assert_eq!(
                 expected_state_root,
                 test_database.state_root(),
-                "{}",
-                format!("failed test: {}", test_case_name)
+                "failed test: {}",
+                test_case_name
             );
 
             tmp_dir.close().unwrap();


### PR DESCRIPTION
Silenced the following warnings to avoid a large delta:

- `clippy::module_inception`: caused by `crate::page::page` (submodule having the same name as the parent module);
- `clippy::too_many_arguments`: caused by multiple functions in `StorageEngine`.

Wanted to enable the following lints but could not:

- `unused_dependencies`: returns false positives because it does not detect dependencies used in `benches`
- `unused_qualifications`: does not play well with the code generated by `proptest`