### PR TITLE
Upgrade `reth-trie-common` to v1.3.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ sealed = "0.6.0"
 metrics-derive = "0.1.0"
 metrics = "0.24.1"
 zerocopy = { version = "0.8.24", features = ["derive"] }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.2.2" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.8" }
 parking_lot = { version = "0.12.3", features = ["send_guard"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Dependency conflict when using TrieDB in Reth.

```
error: failed to select a version for `c-kzg`.
    ... required by package `revm-precompile v16.1.0`
    ... which satisfies dependency `revm-precompile = "^16.1.0"` of package `revm v19.5.0`
    ... which satisfies dependency `revm = "^19.5.0"` of package `reth-trie-common v1.2.2 (https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b)`
    ... which satisfies git dependency `reth-trie-common` of package `triedb v0.1.0 (ssh://git@github.com/base/triedb.git#36fbd476)`
    ... which satisfies git dependency `triedb` of package `reth-provider v1.3.5 (/Users/ianlai/Workspace/paradigmxyz/reth/crates/storage/provider)`
    ... which satisfies path dependency `reth-provider` of package `ef-tests v1.3.5 (/Users/ianlai/Workspace/paradigmxyz/reth/testing/ef-tests)`
versions that meet the requirements `^1.0.3` are: 1.0.3
```