### PR TITLE
fix: Make TransactionContextInner Sync + Send

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,7 +1,9 @@
-use std::{cell::RefCell, mem};
+use std::mem;
 
 use metrics::{Counter, Histogram};
 use metrics_derive::Metrics;
+
+use parking_lot::RwLock;
 
 #[derive(Metrics, Clone)]
 #[metrics(scope = "triedb")]
@@ -39,61 +41,68 @@ struct TransactionMetricsInner {
     cache_storage_read_miss: u32,
 }
 
+// Compile-time assertion to ensure that `TransactionMetricsInner` is `Sync`
+const _: fn() = || {
+    fn consumer<T: Sync + Send>() {}
+    consumer::<TransactionMetricsInner>();
+    consumer::<TransactionMetricsInner>();
+};
+
 #[derive(Debug, Default)]
 pub(crate) struct TransactionMetrics {
-    inner: RefCell<TransactionMetricsInner>,
+    inner: RwLock<TransactionMetricsInner>,
 }
 
 impl TransactionMetrics {
     pub(crate) fn inc_pages_read(&self) {
-        self.inner.borrow_mut().pages_read += 1;
+        self.inner.write().pages_read += 1;
     }
 
     pub(crate) fn inc_pages_split(&self) {
-        self.inner.borrow_mut().pages_split += 1;
+        self.inner.write().pages_split += 1;
     }
 
     pub(crate) fn inc_pages_allocated(&self) {
-        self.inner.borrow_mut().pages_allocated += 1;
+        self.inner.write().pages_allocated += 1;
     }
 
     pub(crate) fn inc_pages_reallocated(&self) {
-        self.inner.borrow_mut().pages_reallocated += 1;
+        self.inner.write().pages_reallocated += 1;
     }
 
     /// Increment the cache storage read hit
     pub(crate) fn inc_cache_storage_read_hit(&self) {
-        self.inner.borrow_mut().cache_storage_read_hit += 1;
+        self.inner.write().cache_storage_read_hit += 1;
     }
 
     /// Increment the cache storage read miss
     pub(crate) fn inc_cache_storage_read_miss(&self) {
-        self.inner.borrow_mut().cache_storage_read_miss += 1;
+        self.inner.write().cache_storage_read_miss += 1;
     }
 
     pub(crate) fn take_pages_read(&self) -> u32 {
-        let mut inner = self.inner.borrow_mut();
+        let mut inner = self.inner.write();
         mem::take(&mut inner.pages_read)
     }
 
     pub(crate) fn take_pages_split(&self) -> u32 {
-        let mut inner = self.inner.borrow_mut();
+        let mut inner = self.inner.write();
         mem::take(&mut inner.pages_split)
     }
 
     pub(crate) fn take_pages_allocated(&self) -> u32 {
-        let mut inner = self.inner.borrow_mut();
+        let mut inner = self.inner.write();
         mem::take(&mut inner.pages_allocated)
     }
 
     pub(crate) fn take_pages_reallocated(&self) -> u32 {
-        let mut inner = self.inner.borrow_mut();
+        let mut inner = self.inner.write();
         mem::take(&mut inner.pages_reallocated)
     }
 
     /// Take the cache storage read hit and miss
     pub(crate) fn take_cache_storage_read(&self) -> (u32, u32) {
-        let mut inner = self.inner.borrow_mut();
+        let mut inner = self.inner.write();
         let cache_storage_read_hit = mem::take(&mut inner.cache_storage_read_hit);
         let cache_storage_read_miss = mem::take(&mut inner.cache_storage_read_miss);
         (cache_storage_read_hit, cache_storage_read_miss)
@@ -101,27 +110,27 @@ impl TransactionMetrics {
 
     #[cfg(test)]
     pub(crate) fn get_pages_read(&self) -> u32 {
-        self.inner.borrow().pages_read
+        self.inner.read().pages_read
     }
 
     #[cfg(test)]
     pub(crate) fn get_pages_split(&self) -> u32 {
-        self.inner.borrow().pages_split
+        self.inner.read().pages_split
     }
 
     #[cfg(test)]
     pub(crate) fn get_pages_allocated(&self) -> u32 {
-        self.inner.borrow().pages_allocated
+        self.inner.read().pages_allocated
     }
 
     #[cfg(test)]
     pub(crate) fn get_pages_reallocated(&self) -> u32 {
-        self.inner.borrow().pages_reallocated
+        self.inner.read().pages_reallocated
     }
 
     #[cfg(test)]
     pub(crate) fn get_cache_storage_read(&self) -> (u32, u32) {
-        let metrics = self.inner.borrow();
+        let metrics = self.inner.read();
         (metrics.cache_storage_read_hit, metrics.cache_storage_read_miss)
     }
 }


### PR DESCRIPTION
During TrieDB integration into Reth we ran into the following error:
![Screenshot 2025-04-11 at 15 42 00](https://github.com/user-attachments/assets/cbc8f119-6be3-428d-888d-f1fea90300ce)


This PR makes sure that the TransactionContextInner is Sync + Send