### PR TITLE
fix: Make `B512Map` and `TransactionContext` support `Sync`

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1,13 +1,14 @@
 use alloy_primitives::{map::FbBuildHasher, FixedBytes};
 use alloy_trie::Nibbles;
-use std::{cell::RefCell, collections::HashMap};
+use parking_lot::RwLock;
+use std::collections::HashMap;
 
 use crate::{database::Metadata, metrics::TransactionMetrics, page::PageId};
 
 /// A map of 64 nibbles (64 bytes). 64 bytes is used instead of 32 bytes to avoid new memory
 /// allocations from Nibbles. This is used to store the nibbles of an address in the context.
 #[derive(Debug)]
-pub struct B512Map<V>(RefCell<HashMap<FixedBytes<64>, V, FbBuildHasher<64>>>);
+pub struct B512Map<V>(RwLock<HashMap<FixedBytes<64>, V, FbBuildHasher<64>>>);
 
 impl<V> B512Map<V>
 where
@@ -19,7 +20,7 @@ where
             FbBuildHasher::default(),
         );
 
-        Self(RefCell::new(map))
+        Self(RwLock::new(map))
     }
 
     /// Inserts a key-value pair into the map.
@@ -28,7 +29,7 @@ where
     ///
     /// Panics if the key is not 64 bytes long.
     pub fn insert(&self, key: &Nibbles, value: V) {
-        self.0.borrow_mut().insert(FixedBytes::from_slice(key.as_slice()), value);
+        self.0.write().insert(FixedBytes::from_slice(key.as_slice()), value);
     }
 
     /// Returns the value associated with the key.
@@ -37,7 +38,7 @@ where
     ///
     /// Panics if the key is not 64 bytes long.
     pub fn get(&self, key: &Nibbles) -> Option<V> {
-        self.0.borrow().get(&FixedBytes::from_slice(key.as_slice())).cloned()
+        self.0.read().get(&FixedBytes::from_slice(key.as_slice())).cloned()
     }
 
     /// Removes the key-value pair associated with the key.
@@ -46,7 +47,7 @@ where
     ///
     /// Panics if the key is not 64 bytes long.
     pub fn remove(&self, key: &Nibbles) {
-        self.0.borrow_mut().remove(&FixedBytes::from_slice(key.as_slice()));
+        self.0.write().remove(&FixedBytes::from_slice(key.as_slice()));
     }
 }
 


### PR DESCRIPTION
Required because of the bounds on Reth's `DBProvider`, and because we are trying to pass TrieDB's transaction in Reth's `DatabaseProvider`:

```
note: required because it appears within the type `providers::database::provider::DatabaseProvider<<DB as reth_db_api::Database>::TXMut, N>`
   --> crates/storage/provider/src/providers/database/provider.rs:137:12
    |
137 | pub struct DatabaseProvider<TX, N: NodeTypes> {
    |            ^^^^^^^^^^^^^^^^
note: required by a bound in `table`
   --> /Users/ianlai/Workspace/paradigmxyz/reth/crates/storage/storage-api/src/database_provider.rs:15:30
    |
15  | pub trait DBProvider: Send + Sync + Sized + 'static {
    |                              ^^^^ required by this bound in `DBProvider::table`
...
48  |     fn table<T: Table>(&self) -> Result<Vec<KeyValue<T>>, DatabaseError>
    |        ----- required by a bound in this associated function
```

This should be the last of the `Sync` compatibility issues.