### PR TITLE
Add `close()` methods to `Database` and `StorageEngine`

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -81,6 +81,10 @@ impl Database {
         }
     }
 
+    pub fn close(self) -> io::Result<()> {
+        self.inner.storage_engine.into_inner().close()
+    }
+
     pub fn print_page<W: io::Write>(self, buf: W, page_id: Option<PageId>) -> Result<(), Error> {
         let storage_engine = self.inner.storage_engine.read();
         let context = storage_engine.read_context();
@@ -151,16 +155,6 @@ impl Database {
         self.inner.storage_engine.read().metadata().active_slot().root_node_hash()
     }
 
-    pub fn close(mut self) -> Result<(), Error> {
-        self.commit()
-    }
-
-    fn commit(&mut self) -> Result<(), Error> {
-        let mut storage_engine = self.inner.storage_engine.write();
-        let context = storage_engine.write_context();
-        storage_engine.commit(&context).map_err(Error::EngineError)
-    }
-
     pub fn size(&self) -> u32 {
         let storage_engine = self.inner.storage_engine.read();
         storage_engine.size()
@@ -190,12 +184,6 @@ impl Database {
         self.metrics
             .rw_transaction_pages_split
             .record(context.transaction_metrics.take_pages_split() as f64);
-    }
-}
-
-impl Drop for Database {
-    fn drop(&mut self) {
-        self.commit().expect("failed to close database")
     }
 }
 

--- a/src/page/manager/mmap.rs
+++ b/src/page/manager/mmap.rs
@@ -3,7 +3,7 @@ use crate::{
     snapshot::SnapshotId,
 };
 use memmap2::{Advice, MmapMut, MmapOptions};
-use std::{fs::File, path::Path};
+use std::{fs::File, io, path::Path};
 
 // Manages pages in a memory mapped file.
 #[derive(Debug)]
@@ -176,8 +176,19 @@ impl PageManager {
     }
 
     /// Syncs pages to the backing file.
-    pub fn commit(&mut self) -> Result<(), PageError> {
-        self.mmap.flush().map_err(PageError::IO)
+    pub fn sync(&mut self) -> io::Result<()> {
+        self.mmap.flush()
+    }
+
+    /// Syncs and closes the backing file.
+    pub fn close(mut self) -> io::Result<()> {
+        self.sync()
+    }
+}
+
+impl Drop for PageManager {
+    fn drop(&mut self) {
+        self.sync().expect("sync failed");
     }
 }
 
@@ -221,8 +232,6 @@ mod tests {
 
         page.contents_mut()[0] = 1;
 
-        manager.commit().unwrap();
-
         let old_page = manager.get(42, page_id!(1)).unwrap();
         assert_eq!(old_page.id(), page_id!(1));
         assert_eq!(old_page.contents()[0], 1);
@@ -243,8 +252,6 @@ mod tests {
         page1_mut.contents_mut()[0] = 2;
 
         assert_eq!(page1_mut.contents()[0], 2);
-
-        manager.commit().unwrap();
 
         let page1 = manager.get(42, page1.id()).unwrap();
         assert_eq!(page1.contents()[0], 2);
@@ -324,7 +331,6 @@ mod tests {
         // Allocate a page; verify that the size of the file grew by `1024 * Page::SIZE` (the
         // minimum growth factor) and that the file contents are as expected
         let mut p = m.allocate(snapshot).expect("page allocation failed");
-        m.commit().expect("commit failed");
         assert_eq!(len(&f), 1024 * Page::SIZE);
         assert_eq!(read(&f, 8), snapshot.to_le_bytes());
         assert_eq!(read(&f, Page::DATA_SIZE), [0; Page::DATA_SIZE]);
@@ -333,7 +339,6 @@ mod tests {
 
         // Write some data to the page
         p.contents_mut().iter_mut().for_each(|byte| *byte = 0xab);
-        m.commit().expect("commit failed");
         assert_eq!(len(&f), 1024 * Page::SIZE);
         assert_eq!(read(&f, 8), snapshot.to_le_bytes());
         assert_eq!(read(&f, Page::DATA_SIZE), [0xab; Page::DATA_SIZE]);
@@ -344,7 +349,6 @@ mod tests {
         for new_page_id in 1..=255 {
             let mut p = m.allocate(snapshot).expect("page allocation failed");
             p.contents_mut().iter_mut().for_each(|byte| *byte = 0xab ^ (new_page_id as u8));
-            m.commit().expect("commit failed");
 
             assert_eq!(len(&f), 1024 * Page::SIZE);
 

--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -50,6 +50,13 @@ impl StorageEngine {
         &self.meta_manager
     }
 
+    pub fn close(self) -> io::Result<()> {
+        let Self { page_manager, meta_manager, .. } = self;
+        page_manager.close()?;
+        meta_manager.close()?;
+        Ok(())
+    }
+
     /// Returns a [`TransactionContext`] valid for reads.
     ///
     /// The returned context points to the latest committed snapshot.
@@ -1889,7 +1896,7 @@ impl StorageEngine {
     }
 
     pub fn commit(&mut self, context: &TransactionContext) -> Result<(), Error> {
-        self.page_manager.commit()?;
+        self.page_manager.sync()?;
 
         let dirty_meta = self.meta_manager.dirty_slot_mut();
         context.update_metadata(dirty_meta);


### PR DESCRIPTION
Explicit `close()` methods allow callers to handle errors.

Also removed `Database::commit()`, which does not really have any visible effect, and simplified some errors.