### PR TITLE
Make TransactionManager faster

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -146,7 +146,7 @@ impl Database {
         let mut transaction_manager = self.inner.transaction_manager.write();
         let storage_engine = self.inner.storage_engine.read();
         let metadata = storage_engine.metadata().active_slot();
-        transaction_manager.begin_ro(metadata.snapshot_id())?;
+        transaction_manager.begin_ro(metadata.snapshot_id());
         let context = storage_engine.read_context();
         Ok(Transaction::new(context, self))
     }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -167,7 +167,7 @@ impl Transaction<'_, RW> {
 
         self.database.update_metrics_rw(&self.context);
 
-        transaction_manager.remove_transaction(self.context.snapshot_id, true)?;
+        transaction_manager.remove_tx(self.context.snapshot_id, true);
 
         self.committed = true;
         Ok(())
@@ -178,7 +178,7 @@ impl Transaction<'_, RW> {
         storage_engine.rollback(&self.context).unwrap();
 
         let mut transaction_manager = self.database.inner.transaction_manager.write();
-        transaction_manager.remove_transaction(self.context.snapshot_id, true)?;
+        transaction_manager.remove_tx(self.context.snapshot_id, true);
 
         self.committed = false;
         Ok(())
@@ -188,7 +188,7 @@ impl Transaction<'_, RW> {
 impl Transaction<'_, RO> {
     pub fn commit(mut self) -> Result<(), TransactionError> {
         let mut transaction_manager = self.database.inner.transaction_manager.write();
-        transaction_manager.remove_transaction(self.context.snapshot_id, false)?;
+        transaction_manager.remove_tx(self.context.snapshot_id, false);
 
         self.committed = true;
         Ok(())


### PR DESCRIPTION
`TransactionManager::begin_ro`/`begin_rw`/`remove_tx` used sorting and binary search for every operation, causing each operation to potentially rewrite every single element in the internal `open_txs` list.

The new implementation is much simpler and faster: it doesn't sort the data, uses linear search, and uses methods like `swap_remove()` to limit the number of writes.

Using an append-only structure with linear serach is generally faster than any sorted data structure for "small" lists (hundreds or thousands elements, like in this case), and plays more nicely with modern CPU architectures with branch prediction.

The table below captures the amortized number of read and write operations before/after this change:

|             | reads before | writes before | reads after | writes after |
|-------------|--------------|---------------|-------------|--------------|
| `begin_ro`  | O(n log n)   | O(n log n)    | O(1)        | O(1)         |
| `begin_rw`  | O(n log n)   | O(n log n)    | O(n)        | O(1)         |
| `remove_tx` | O(log n)     | O(n)          | O(n)        | O(1)         |

This commit also removes some unsed logic, and removes error return values where no errors are produced.