### PR TITLE
Change the rwlock around `TransactionManager` to a mutex

### DIFF
--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -132,7 +132,7 @@ impl Transaction<'_, RW> {
             storage_engine.set_values(&mut self.context, changes.as_mut()).unwrap();
         }
 
-        let mut transaction_manager = self.database.transaction_manager.write();
+        let mut transaction_manager = self.database.transaction_manager.lock();
         storage_engine.commit(&self.context).unwrap();
 
         self.database.update_metrics_rw(&self.context);
@@ -147,7 +147,7 @@ impl Transaction<'_, RW> {
         let storage_engine = self.database.storage_engine.write();
         storage_engine.rollback(&self.context).unwrap();
 
-        let mut transaction_manager = self.database.transaction_manager.write();
+        let mut transaction_manager = self.database.transaction_manager.lock();
         transaction_manager.remove_tx(self.context.snapshot_id, true);
 
         self.committed = false;
@@ -157,7 +157,7 @@ impl Transaction<'_, RW> {
 
 impl Transaction<'_, RO> {
     pub fn commit(mut self) -> Result<(), TransactionError> {
-        let mut transaction_manager = self.database.transaction_manager.write();
+        let mut transaction_manager = self.database.transaction_manager.lock();
         transaction_manager.remove_tx(self.context.snapshot_id, false);
 
         self.committed = true;


### PR DESCRIPTION
Read/write locks are quite expensive compared to mutexes. Operations involving `TransactionManager` are very fast so there is no benefit in using a read/write lock for it. Besides, `TransactionManager` is never used in read-only mode.