### PR TITLE
Display root page info

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,48 +1,32 @@
-#CLI Tools for TrieDB#
+# CLI Tools for TrieDB #
 
 Commands should be called from the `/cli` folder for an existing database. 
 
-###Print Page###
-To print a single page of a database:
+### Print Page ###
+To print a single page of a database:  
 `cargo run print -d <path to database> [-p <page_id of page to print>] [-o <output path>]`
 
-To print the whole database, omit the `page_id `:
-`cargo run print -d <path to database> 
+To print the whole database, omit the `page_id`:  
+`cargo run print -d <path to database>` 
 
 
-###Print TrieValue Info###
-cargo run trie-value -d <path to database> -i <node identifier> [-v <verbose options>]
+### Print TrieValue Info ###
+`cargo run trie-value -d <path to database> -i <node identifier> [-v <verbose options>]`
 
-Node identifier must be in one of these formats:
-    1. Address (<0x40 hex chars>)
-    2. Address hash (<0x64 hex chars>)
-    3. Address hash + storage hash (<0x128 hex chars>)
-    4. Address with storage slot, space separated (<0x40 hex chars> <slot>)
+Node identifier must be in one of these formats:  
+  1. Address (<0x40 hex chars>)  
+  2. Address hash (<0x64 hex chars>)  
+  3. Address hash + storage hash (<0x128 hex chars>)  
+  4. Address with storage slot, space separated (<0x40 hex chars> <slot>)  
 
-Verbose options vary the level of information written to file:
-    1. None: only the account/storage node information
-    2. Verbose (-v verbose): Node information for every node accessed along path to specified node
-    3. Extra Verbose (-v extra-verbose): Information for each page accessed followed by information for each node accessed from that page along path to specified node
-
-
-###Print TrieValue Info###
-Prints information about a given node to file
-`cargo run trie-value -d <path to database> -i <node identifier> [-v <verbose options>] [-o <output path>]`
-
-Node identifier must be in one of these formats:
-    1. Address (<0x40 hex chars>)
-    2. Address hash (<0x64 hex chars>)
-    3. Address hash + storage hash (<0x128 hex chars>)
-    4. Address with storage slot, space separated (<0x40 hex chars> <slot>)
-
-Verbose options vary the level of information written to file:
-    1. None: only the account/storage node information
-    2. Verbose (-v verbose): Node information for every node accessed along path to specified node
-    3. Extra Verbose (-v extra-verbose): Information for each page accessed followed by information for each node accessed from that page along path to specified node
+Verbose options vary the level of information written to file:  
+  1. None: only the account/storage node information
+  2. Verbose (-v verbose): Node information for every node accessed along path to specified node
+  3. Extra Verbose (-v extra-verbose): Information for each page accessed followed by information for each node accessed from that page along path to specified node
 
 
-###Print Root Page Info###
-Prints the state root, root subtrie page ID, and orphaned pages list.
+### Print Root Page Info ###
+Prints the state root, root subtrie page ID, and orphaned pages list.  
 `cargo run root-page -d <path to database> [-o <output path>]`
 
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -238,7 +238,7 @@ fn root_page_info(db_path: &str, output_path: &str) -> Result<(), Box<dyn std::e
     };
 
     let output_file = File::create(output_path).unwrap();
-    match db.root_page_info(db_path, &output_file) {
+    match db.root_page_info(output_file, db_path) {
         Ok(_) => println!("Info written to {}", output_path),
         Err(e) => println!("Error printing root page info: {:?}", e),
     }


### PR DESCRIPTION
Displays state root, root subtrie page ID, and orphaned pages list for given database.

Note: needs to be merged after [107](https://github.com/base/triedb/pull/107 )