### PR TITLE
perf: Dont retry the processed changes

### DIFF
--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -291,7 +291,7 @@ impl StorageEngine {
     fn set_values_in_page(
         &mut self,
         context: &mut TransactionContext,
-        changes: &[(Nibbles, Option<TrieValue>)],
+        mut changes: &[(Nibbles, Option<TrieValue>)],
         path_offset: u8,
         page_id: PageId,
     ) -> Result<PointerChange, Error> {
@@ -323,7 +323,8 @@ impl StorageEngine {
                 // that a page will be consistently evaluated, and not modified in
                 // the middle of an operation, which could result in inconsistent
                 // cell pointers.
-                Err(Error::PageSplit) => {
+                Err(Error::PageSplit(handled_total)) => {
+                    changes = &changes[handled_total..];
                     context.transaction_metrics.inc_pages_split();
                     split_count += 1;
                     // FIXME: this is a temporary limit to prevent infinite loops.
@@ -499,7 +500,7 @@ impl StorageEngine {
         // TODO: use a more accurate threshold
         if slotted_page.num_free_bytes() < 1000 {
             self.split_page(context, slotted_page)?;
-            return Err(Error::PageSplit);
+            return Err(Error::PageSplit(0));
         }
 
         // Create a new branch node with the common prefix
@@ -581,7 +582,7 @@ impl StorageEngine {
             let node_size_incr = new_node_size - old_node_size;
             if slotted_page.num_free_bytes() < node_size_incr {
                 self.split_page(context, slotted_page)?;
-                return Err(Error::PageSplit);
+                return Err(Error::PageSplit(0));
             }
         }
 
@@ -736,7 +737,7 @@ impl StorageEngine {
         // when adding the new child, split the page.
         if slotted_page.num_free_bytes() < node_size_incr + new_node.size() + CELL_POINTER_SIZE {
             self.split_page(context, slotted_page)?;
-            return Err(Error::PageSplit);
+            return Err(Error::PageSplit(0));
         }
 
         let rlp_node = new_node.as_rlp_node();
@@ -796,6 +797,7 @@ impl StorageEngine {
     ) -> Result<PointerChange, Error> {
         // Partition changes by child index
         let mut remaining_changes = changes;
+        let mut handled_in_children: usize = 0;
 
         for child_index in 0..16 {
             let matching_changes;
@@ -807,34 +809,145 @@ impl StorageEngine {
             if matching_changes.is_empty() {
                 continue;
             }
+            let result = self.handle_child_node_traversal(
+                context,
+                matching_changes,
+                path_offset,
+                slotted_page,
+                page_index,
+                node,
+                common_prefix_length,
+                child_index,
+            );
+            match result {
+                Err(Error::PageSplit(processed)) => {
+                    return Err(Error::PageSplit(handled_in_children + processed));
+                }
+                Err(e) => {
+                    return Err(e);
+                }
+                _ => {}
+            }
+            handled_in_children += matching_changes.len();
+        }
+        assert!(handled_in_children == changes.len(), "all changes should be handled");
 
-            // Get the child pointer for this index
-            let child_pointer = node.child(child_index)?;
+        // Check if the branch node should be deleted or merged
+        self.handle_branch_node_cleanup(context, slotted_page, page_index, node)
+    }
 
-            match child_pointer {
-                Some(child_pointer) => {
-                    // Child exists, traverse it
-                    let child_location = child_pointer.location();
-                    let child_pointer_change =
-                        if let Some(child_cell_index) = child_location.cell_index() {
-                            // Local child node
-                            self.set_values_in_cloned_page(
-                                context,
-                                matching_changes,
-                                path_offset + common_prefix_length as u8 + 1,
-                                slotted_page,
-                                child_cell_index,
-                            )?
-                        } else {
-                            // Remote child node
-                            let child_page_id = child_location.page_id().unwrap();
-                            self.set_values_in_page(
-                                context,
-                                matching_changes,
-                                path_offset + common_prefix_length as u8 + 1,
-                                child_page_id,
-                            )?
-                        };
+    fn handle_child_node_traversal(
+        &mut self,
+        context: &mut TransactionContext,
+        matching_changes: &[(Nibbles, Option<TrieValue>)],
+        path_offset: u8,
+        slotted_page: &mut SlottedPageMut<'_>,
+        page_index: u8,
+        node: &mut Node,
+        common_prefix_length: usize,
+        child_index: u8,
+    ) -> Result<(), Error> {
+        // Get the child pointer for this index
+        let child_pointer = node.child(child_index)?;
+
+        match child_pointer {
+            Some(child_pointer) => {
+                // Child exists, traverse it
+                let child_location = child_pointer.location();
+                let child_pointer_change =
+                    if let Some(child_cell_index) = child_location.cell_index() {
+                        // Local child node
+                        self.set_values_in_cloned_page(
+                            context,
+                            matching_changes,
+                            path_offset + common_prefix_length as u8 + 1,
+                            slotted_page,
+                            child_cell_index,
+                        )?
+                    } else {
+                        // Remote child node
+                        let child_page_id = child_location.page_id().unwrap();
+                        self.set_values_in_page(
+                            context,
+                            matching_changes,
+                            path_offset + common_prefix_length as u8 + 1,
+                            child_page_id,
+                        )?
+                    };
+
+                match child_pointer_change {
+                    PointerChange::Update(new_child_pointer) => {
+                        self.update_node_child(
+                            node,
+                            slotted_page,
+                            page_index,
+                            Some(new_child_pointer),
+                            child_index,
+                        )?;
+                    }
+                    PointerChange::Delete => {
+                        self.update_node_child(node, slotted_page, page_index, None, child_index)?;
+                    }
+                    PointerChange::None => {}
+                }
+            }
+            None => {
+                // the child node does not exist, so we need to create a new leaf node with the
+                // remaining path.
+
+                // in this case, if the change(s) we want to make are deletes, they should be
+                // ignored as the child node already doesn't exist.
+                let index_of_first_non_delete_change =
+                    matching_changes.iter().position(|(_, value)| value.is_some());
+
+                let matching_changes_without_leading_deletes =
+                    match index_of_first_non_delete_change {
+                        Some(index) => &matching_changes[index..],
+                        None => &[],
+                    };
+
+                if matching_changes_without_leading_deletes.is_empty() {
+                    return Ok(());
+                }
+
+                let ((path, value), matching_changes) =
+                    matching_changes_without_leading_deletes.split_first().unwrap();
+                let remaining_path: Nibbles =
+                    path.slice(path_offset as usize + common_prefix_length + 1..);
+
+                let value = value.as_ref().unwrap();
+
+                // ensure that the page has enough space to insert a new leaf node.
+                let node_size_incr = node.size_incr_with_new_child();
+                let new_node = Node::new_leaf(remaining_path, value)?;
+
+                // if the page doesn't have enough space to
+                // 1. insert the new leaf node
+                // 2. and the node (branch) size increase
+                // 3. and add new cell pointer for the new leaf node (3 bytes)
+                // when adding the new child, split the page.
+                // FIXME: is it safe to split the page here if we've already modified the page?
+                if slotted_page.num_free_bytes() <
+                    node_size_incr + new_node.size() + CELL_POINTER_SIZE
+                {
+                    self.split_page(context, slotted_page)?;
+                    return Err(Error::PageSplit(0));
+                }
+
+                let rlp_node = new_node.as_rlp_node();
+                let location = Location::for_cell(slotted_page.insert_value(&new_node)?);
+                node.set_child(child_index, Pointer::new(location, rlp_node))?;
+                slotted_page.set_value(page_index, node)?;
+
+                // If there are more matching changes, recurse
+                if !matching_changes.is_empty() {
+                    let child_pointer_change = self.set_values_in_cloned_page(
+                        context,
+                        matching_changes,
+                        path_offset + common_prefix_length as u8 + 1,
+                        slotted_page,
+                        location.cell_index().unwrap(),
+                    )?;
 
                     match child_pointer_change {
                         PointerChange::Update(new_child_pointer) => {
@@ -858,92 +971,9 @@ impl StorageEngine {
                         PointerChange::None => {}
                     }
                 }
-                None => {
-                    // the child node does not exist, so we need to create a new leaf node with the
-                    // remaining path.
-
-                    // in this case, if the change(s) we want to make are deletes, they should be
-                    // ignored as the child node already doesn't exist.
-                    let index_of_first_non_delete_change =
-                        matching_changes.iter().position(|(_, value)| value.is_some());
-
-                    let matching_changes_without_leading_deletes =
-                        match index_of_first_non_delete_change {
-                            Some(index) => &matching_changes[index..],
-                            None => &[],
-                        };
-
-                    if matching_changes_without_leading_deletes.is_empty() {
-                        continue;
-                    }
-
-                    let ((path, value), matching_changes) =
-                        matching_changes_without_leading_deletes.split_first().unwrap();
-                    let remaining_path: Nibbles =
-                        path.slice(path_offset as usize + common_prefix_length + 1..);
-
-                    let value = value.as_ref().unwrap();
-
-                    // ensure that the page has enough space to insert a new leaf node.
-                    let node_size_incr = node.size_incr_with_new_child();
-                    let new_node = Node::new_leaf(remaining_path, value)?;
-
-                    // if the page doesn't have enough space to
-                    // 1. insert the new leaf node
-                    // 2. and the node (branch) size increase
-                    // 3. and add new cell pointer for the new leaf node (3 bytes)
-                    // when adding the new child, split the page.
-                    // FIXME: is it safe to split the page here if we've already modified the page?
-                    if slotted_page.num_free_bytes() <
-                        node_size_incr + new_node.size() + CELL_POINTER_SIZE
-                    {
-                        self.split_page(context, slotted_page)?;
-                        return Err(Error::PageSplit);
-                    }
-
-                    let rlp_node = new_node.as_rlp_node();
-                    let location = Location::for_cell(slotted_page.insert_value(&new_node)?);
-                    node.set_child(child_index, Pointer::new(location, rlp_node))?;
-                    slotted_page.set_value(page_index, node)?;
-
-                    // If there are more matching changes, recurse
-                    if !matching_changes.is_empty() {
-                        let child_pointer_change = self.set_values_in_cloned_page(
-                            context,
-                            matching_changes,
-                            path_offset + common_prefix_length as u8 + 1,
-                            slotted_page,
-                            location.cell_index().unwrap(),
-                        )?;
-
-                        match child_pointer_change {
-                            PointerChange::Update(new_child_pointer) => {
-                                self.update_node_child(
-                                    node,
-                                    slotted_page,
-                                    page_index,
-                                    Some(new_child_pointer),
-                                    child_index,
-                                )?;
-                            }
-                            PointerChange::Delete => {
-                                self.update_node_child(
-                                    node,
-                                    slotted_page,
-                                    page_index,
-                                    None,
-                                    child_index,
-                                )?;
-                            }
-                            PointerChange::None => {}
-                        }
-                    }
-                }
             }
         }
-
-        // Check if the branch node should be deleted or merged
-        self.handle_branch_node_cleanup(context, slotted_page, page_index, node)
+        Ok(())
     }
 
     /// Handles cleanup of branch nodes (deletion or merging)
@@ -1761,7 +1791,7 @@ pub enum Error {
     PageError(PageError),
     InvalidCommonPrefixIndex,
     InvalidSnapshotId,
-    PageSplit,
+    PageSplit(usize),
     DebugError(String),
 }
 


### PR DESCRIPTION
Current engine: When there is a PageSplit error, it bubbles up to set_value_in_page and retry all the changes.
This is not very effective given many changes has been applied successfully.

This PR updates PageSplit error to include a number of processed changes so that we exclude them from the list of changes to be run again.

The following show logs at set_value_in_page the size of handled changes, and size of remaining changes:

```
main branch (remaining size is 99998 constantly):
1:Root page split, page id: 256, total changes: 99998, handled: 0, remaining: 99998
282:Root page split, page id: 256, total changes: 99998, handled: 0, remaining: 99998
568:Root page split, page id: 256, total changes: 99998, handled: 0, remaining: 99998
852:Root page split, page id: 256, total changes: 99998, handled: 0, remaining: 99998
1138:Root page split, page id: 256, total changes: 99998, handled: 0, remaining: 99998
1416:Root page split, page id: 256, total changes: 99998, handled: 0, remaining: 99998
1697:Root page split, page id: 256, total changes: 99998, handled: 0, remaining: 99998
1988:Root page split, page id: 256, total changes: 99998, handled: 0, remaining: 99998
2263:Root page split, page id: 256, total changes: 99998, handled: 0, remaining: 99998
2540:Root page split, page id: 256, total changes: 99998, handled: 0, remaining: 99998
2815:Root page split, page id: 256, total changes: 99998, handled: 0, remaining: 99998
3105:Root page split, page id: 256, total changes: 99998, handled: 0, remaining: 99998
3386:Root page split, page id: 256, total changes: 99998, handled: 0, remaining: 99998
3666:Root page split, page id: 256, total changes: 99998, handled: 0, remaining: 99998
3946:Root page split, page id: 256, total changes: 99998, handled: 0, remaining: 99998
4221:Root page split, page id: 256, total changes: 99998, handled: 0, remaining: 99998

this PR (the remaining size going down from original 99998):
1:Root page split, page id: 256, total changes: 99998, handled: 26, remaining: 99972
282:Root page split, page id: 256, total changes: 99972, handled: 6265, remaining: 93707
568:Root page split, page id: 256, total changes: 93707, handled: 6281, remaining: 87426
852:Root page split, page id: 256, total changes: 87426, handled: 6247, remaining: 81179
1138:Root page split, page id: 256, total changes: 81179, handled: 6258, remaining: 74921
1416:Root page split, page id: 256, total changes: 74921, handled: 6138, remaining: 68783
1697:Root page split, page id: 256, total changes: 68783, handled: 6211, remaining: 62572
1988:Root page split, page id: 256, total changes: 62572, handled: 6298, remaining: 56274
2263:Root page split, page id: 256, total changes: 56274, handled: 6183, remaining: 50091
2540:Root page split, page id: 256, total changes: 50091, handled: 6230, remaining: 43861
2815:Root page split, page id: 256, total changes: 43861, handled: 6236, remaining: 37625
3105:Root page split, page id: 256, total changes: 37625, handled: 6448, remaining: 31177
3386:Root page split, page id: 256, total changes: 31177, handled: 6214, remaining: 24963
3666:Root page split, page id: 256, total changes: 24963, handled: 6337, remaining: 18626
3946:Root page split, page id: 256, total changes: 18626, handled: 6337, remaining: 12289
4221:Root page split, page id: 256, total changes: 12289, handled: 6096, remaining: 6193
```

Inserting 1M accounts, 3M accounts, and 3M accounts show sig time reducing (which also means benchmark will be shorter)

```
For 1M accounts:
Main:
./target/release/examples/insert  18.22s user 0.36s system 96% cpu 19.245 total
New:
./target/release/examples/insert  3.37s user 0.25s system 88% cpu 4.084 total

For 3M accounts
Main:
./target/release/examples/insert  62.66s user 150.44s system 99% cpu 3:34.46 total
New:
./target/release/examples/insert  10.73s user 150.73s system 99% cpu 2:42.09 total

For 5M accounts:
Main:
./target/release/examples/insert  108.75s user 159.48s system 99% cpu 4:29.97 total
New:
./target/release/examples/insert  18.83s user 162.12s system 99% cpu 3:01.91 total
```
