### PR TITLE
fix: Do not create a new (empty) db when calling open

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -80,8 +80,11 @@ impl Database {
     }
 
     pub fn open(file_path: impl AsRef<Path>) -> Result<Self, Error> {
-        let mut page_manager =
-            PageManager::options().page_count(256).open(file_path).map_err(Error::PageError)?;
+        let mut page_manager = PageManager::options()
+            .create(false)
+            .page_count(256)
+            .open(file_path)
+            .map_err(Error::PageError)?;
 
         let root_page_0 = page_manager.get(0, 0).map_err(Error::PageError)?;
         let root_page_1 = page_manager.get(0, 1).map_err(Error::PageError)?;


### PR DESCRIPTION
Previously `Database::open` would create a new db file if it does not exist. Because it also expects the file to have at least 256 pages of data, this results in an assertion failure and panic. It's better to simply return an IO error (file not found), in order to allow the caller to fail gracefully or fall back to calling `Database::create`