### PR TITLE
Optimize find slot in used space with allocated vector

### DIFF
--- a/src/page/slotted_page.rs
+++ b/src/page/slotted_page.rs
@@ -9,7 +9,7 @@ use std::{
 
 pub(crate) mod cell_pointer;
 
-const MAX_NUM_CELLS: usize = 255; // With 1 byte for the number of cells, the maximum number of cells is 255.
+const MAX_NUM_CELLS: u8 = 255; // With 1 byte for the number of cells, the maximum number of cells is 255.
 pub const CELL_POINTER_SIZE: usize = 3;
 
 // A page that contains a sequence of pointers to variable-length values,
@@ -217,7 +217,7 @@ impl SlottedPageMut<'_> {
                 return Ok(i);
             }
         }
-        if num_cells as usize == MAX_NUM_CELLS {
+        if num_cells == MAX_NUM_CELLS {
             return Err(PageError::NoFreeCells);
         }
         Ok(num_cells)


### PR DESCRIPTION
The vector reallocation is taking about 30% of `find_available_slot_in_used_space`.
<img width="1584" alt="image" src="https://github.com/user-attachments/assets/25c5c985-e1ed-4a6b-b8bc-e287a0c5024e" />

We setup the `used_space` with max possible capacity to avoid mem reallocation.

Another option is use `ArrayVec::<_, MAX_NUM_CELLS>::new();` to allocate used_space in heap. Result shows little different in performance. The array vec also need to allocate 256 items which is quite large for normal number of slots.

