### PR TITLE
Use an opaque, bound-checked type for `PageId`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ zerocopy = { version = "0.8.24", features = ["derive"] }
 reth-trie-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.8" }
 parking_lot = { version = "0.12.3", features = ["send_guard"] }
 fxhash = "0.2.1"
+static_assertions = "1.1.0"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2608,6 +2608,7 @@ dependencies = [
  "proptest-derive",
  "reth-trie-common",
  "sealed",
+ "static_assertions",
  "zerocopy 0.8.24",
 ]
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,6 +5,7 @@ use std::{fs::File, str};
 use triedb::{
     path::{AddressPath, StoragePath},
     Database,
+    page::PageId,
 };
 
 #[derive(Debug)]
@@ -45,7 +46,7 @@ enum Commands {
 
         /// Page ID to print (optional)
         #[arg(short = 'p', long = "page")]
-        page_id: Option<u32>,
+        page_id: Option<PageId>,
 
         /// Output filepath (optional)
         #[arg(short = 'o', long = "output", default_value = "./printed_page")]
@@ -165,7 +166,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn print_page(db_path: &str, page_id: Option<u32>, output_path: &str) {
+fn print_page(db_path: &str, page_id: Option<PageId>, output_path: &str) {
     let db = match Database::open(db_path) {
         Ok(db) => db,
         Err(e) => panic!("Could not open database: {:?}", e),

--- a/src/context.rs
+++ b/src/context.rs
@@ -51,8 +51,8 @@ where
 pub struct TransactionContext {
     pub(crate) snapshot_id: SnapshotId,
     pub(crate) root_node_hash: B256,
-    pub(crate) root_node_page_id: PageId,
-    pub(crate) page_count: PageId,
+    pub(crate) root_node_page_id: Option<PageId>,
+    pub(crate) page_count: u32,
     pub(crate) transaction_metrics: TransactionMetrics,
     pub(crate) contract_account_loc_cache: B512Map<(PageId, u8)>,
 }

--- a/src/page.rs
+++ b/src/page.rs
@@ -1,7 +1,224 @@
+use proptest_derive::Arbitrary;
+use std::{
+    cmp, fmt,
+    num::{NonZero, ParseIntError, TryFromIntError},
+    str::FromStr,
+};
+use zerocopy::{Immutable, IntoBytes, KnownLayout};
+
 mod manager;
 mod page;
 mod slotted_page;
 
-pub use manager::{mmap::PageManager, options::PageManagerOptions, PageError, PageId};
+pub use manager::{mmap::PageManager, options::PageManagerOptions, PageError};
 pub use page::{Page, PageMut};
 pub use slotted_page::{SlottedPage, SlottedPageMut, CELL_POINTER_SIZE};
+
+/// Primitive type for [`PageId`].
+///
+/// This is an integer type large enough to contain all valid values for [`PageId`]. Every `PageId`
+/// can be converted to a `RawPageId`, but not all `RawPageId`s are valid `PageId`s.
+///
+/// `PageId` can be converted to/from `RawPageId` using [`PageId::new()`] and [`PageId::as_u32()`].
+pub type RawPageId = u32;
+
+/// Type representing an ID for [`Page`] objects.
+///
+/// IDs range from 1 to `u32::MAX - 255` (inclusive). The reasons for the bounds are the following:
+///
+/// * the value 0 is used in several places as a special value to signify a null pointer;
+/// * [`triedb::Location`] reserves a special role for integers in the range from 0 to 255
+///   (inclusive), and `PageId` values inside `Location` are represented by adding 255 to them.
+///
+/// `PageId` offers the following memory layout optimization: `Option<PageId>` has the same size as
+/// `PageId`, which in turn has the same size as `u32`.
+#[repr(transparent)]
+#[derive(
+    IntoBytes,
+    Immutable,
+    KnownLayout,
+    Copy,
+    Clone,
+    Arbitrary,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Debug,
+)]
+pub struct PageId(NonZero<u32>);
+
+// Verify the memory layout optimization of `PageId`, that is: `PageId`, `Option<PageId>`, and
+// `u32` all have the same size.
+static_assertions::assert_eq_size!(PageId, Option<PageId>, u32);
+
+impl PageId {
+    /// Minimum valid value for a `PageId`.
+    pub const MIN: Self = Self(NonZero::new(1).unwrap());
+    /// Maximum valid value for a `PageId`.
+    pub const MAX: Self = Self(NonZero::new(u32::MAX - 255).unwrap());
+
+    #[inline]
+    #[must_use]
+    const fn is_valid(id: u32) -> bool {
+        id >= Self::MIN.as_u32() && id <= Self::MAX.as_u32()
+    }
+
+    /// Constructs a new `PageId` from an `u32`.
+    #[inline]
+    #[must_use]
+    pub const fn new(id: u32) -> Option<Self> {
+        if Self::is_valid(id) {
+            Some(unsafe { Self::new_unchecked(id) })
+        } else {
+            None
+        }
+    }
+
+    /// Constructs a new `PageId` from an `u32` without performing any check.
+    ///
+    /// # Safety
+    ///
+    /// `id` must be between [`PageId::MIN`]` and [`PageId::MAX`] (inclusive).
+    #[inline]
+    #[must_use]
+    pub const unsafe fn new_unchecked(id: u32) -> Self {
+        debug_assert!(
+            Self::is_valid(id),
+            "PageId::new_unchecked requires the argument to be between PageId::MIN and PageId::MAX"
+        );
+        Self(NonZero::new_unchecked(id))
+    }
+
+    /// Returns the page ID as an `u32`.
+    #[inline]
+    #[must_use]
+    pub const fn as_u32(&self) -> u32 {
+        self.0.get()
+    }
+
+    /// Returns the page ID as an `usize`.
+    #[inline]
+    #[must_use]
+    pub const fn as_usize(&self) -> usize {
+        self.as_u32() as usize
+    }
+
+    /// Returns the byte offset where the page would be located inside a page file.
+    #[inline]
+    #[must_use]
+    pub const fn as_offset(&self) -> usize {
+        (self.as_usize() - 1) * Page::SIZE
+    }
+
+    /// Increments the `PageId` by 1.
+    ///
+    /// Returns `None` in case the operation would overflow (exceeding [`PageId::MAX`]).
+    #[inline]
+    #[must_use]
+    pub fn inc(&self) -> Option<Self> {
+        self.as_u32().checked_add(1).and_then(Self::new)
+    }
+}
+
+impl TryFrom<u32> for PageId {
+    type Error = TryFromIntError;
+
+    #[inline]
+    fn try_from(id: u32) -> Result<Self, Self::Error> {
+        Self::new(id).ok_or_else(|| {
+            // It's not possible to directly construct a `TryFromIntError`, so we just steal it
+            // from another function.
+            NonZero::try_from(0).unwrap_err()
+        })
+    }
+}
+
+impl From<PageId> for u32 {
+    fn from(id: PageId) -> Self {
+        id.0.get()
+    }
+}
+
+impl From<PageId> for NonZero<u32> {
+    fn from(id: PageId) -> Self {
+        id.0
+    }
+}
+
+impl PartialEq<u32> for PageId {
+    #[inline]
+    fn eq(&self, other: &u32) -> bool {
+        self.0.get().eq(other)
+    }
+}
+
+impl PartialOrd<u32> for PageId {
+    #[inline]
+    fn partial_cmp(&self, other: &u32) -> Option<cmp::Ordering> {
+        self.0.get().partial_cmp(other)
+    }
+}
+
+impl PartialEq<PageId> for u32 {
+    #[inline]
+    fn eq(&self, other: &PageId) -> bool {
+        self.eq(&other.0.get())
+    }
+}
+
+impl PartialOrd<PageId> for u32 {
+    #[inline]
+    fn partial_cmp(&self, other: &PageId) -> Option<cmp::Ordering> {
+        self.partial_cmp(&other.0.get())
+    }
+}
+
+impl fmt::Display for PageId {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.get().fmt(f)
+    }
+}
+
+impl FromStr for PageId {
+    type Err = ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let value = NonZero::<u32>::from_str(s)?.get();
+        Self::new(value).ok_or_else(|| {
+            // Like for `TryFromIntError`, it is not possible to construct a `ParseIntError`, so we
+            // just steal the error by trying to create an `u32` from a string that is too large to
+            // be represented as an `u32`.
+            u32::from_str("5000000000").unwrap_err()
+        })
+    }
+}
+
+/// Helper macro to construct [`PageId`] from a `const` expression.
+///
+/// This macro checks at compile time that the given ID is valid and returns a `PageId` object
+/// (unlike `PageId::new()`, which returns an `Option<PageId>`, and unlike
+/// `PageId::new_unchecked()`, which is `unsafe`).
+///
+/// This macro is mainly useful for tests, where page IDs are often hardcoded integers.
+///
+/// # Example
+///
+/// ```
+/// use triedb::page::{page_id, PageId};
+///
+/// let id = page_id!(123);
+/// assert_eq!(id, PageId::new(123).unwrap());
+/// ```
+#[macro_export]
+macro_rules! page_id {
+    ( $id:expr ) => {{
+        const MAYBE_ID: Option<$crate::page::PageId> = $crate::page::PageId::new($id);
+        ::static_assertions::const_assert!(MAYBE_ID.is_some());
+        MAYBE_ID.expect("id was checked for validity at compile-time")
+    }};
+}
+
+pub use page_id;

--- a/src/page/manager.rs
+++ b/src/page/manager.rs
@@ -1,15 +1,12 @@
+use crate::page::PageId;
+
 pub(super) mod mmap;
 pub(super) mod options;
-
-/// Type alias for page ids.
-/// Currently we use 4 bytes for page ids, which implies a maximum of 16TB of data.
-pub type PageId = u32;
 
 /// Represents various errors that might arise from page operations.
 #[derive(Debug)]
 pub enum PageError {
     PageNotFound(PageId),
-    OutOfBounds(PageId),
     PageLimitReached,
     InvalidRootPage(PageId),
     InvalidCellPointer,

--- a/src/page/manager/options.rs
+++ b/src/page/manager/options.rs
@@ -1,4 +1,4 @@
-use crate::page::{PageError, PageId, PageManager};
+use crate::page::{Page, PageError, PageManager};
 use std::{
     fs::{File, OpenOptions},
     path::Path,
@@ -7,8 +7,8 @@ use std::{
 #[derive(Clone, Debug)]
 pub struct PageManagerOptions {
     pub(super) open_options: OpenOptions,
-    pub(super) page_count: PageId,
-    pub(super) max_pages: PageId,
+    pub(super) page_count: u32,
+    pub(super) max_pages: u32,
 }
 
 impl PageManagerOptions {
@@ -17,11 +17,11 @@ impl PageManagerOptions {
         open_options.read(true).write(true).create(true).truncate(false);
 
         let max_pages = if cfg!(not(test)) {
-            PageId::MAX
+            Page::MAX_COUNT
         } else {
             // Because tests run in parallel, it's easy to exhaust the address space, so use a more
             // conservative limit
-            PageId::MAX / 1024
+            Page::MAX_COUNT / 1024
         };
 
         Self { open_options, page_count: 0, max_pages }
@@ -48,7 +48,7 @@ impl PageManagerOptions {
     /// Sets the number of pages already written to the file.
     ///
     /// The default is `0`.
-    pub fn page_count(&mut self, page_count: PageId) -> &mut Self {
+    pub fn page_count(&mut self, page_count: u32) -> &mut Self {
         self.page_count = page_count;
         self
     }
@@ -56,7 +56,7 @@ impl PageManagerOptions {
     /// Sets the maximum number of pages that can be allocated to this file.
     ///
     /// The default is [`PageId::MAX`].
-    pub fn max_pages(&mut self, max_pages: PageId) -> &mut Self {
+    pub fn max_pages(&mut self, max_pages: u32) -> &mut Self {
         self.max_pages = max_pages;
         self
     }

--- a/src/page/page.rs
+++ b/src/page/page.rs
@@ -76,6 +76,8 @@ impl<'p> Page<'p> {
     pub const HEADER_SIZE: usize = 8;
     pub const DATA_SIZE: usize = Self::SIZE - Self::HEADER_SIZE;
 
+    pub const MAX_COUNT: u32 = PageId::MAX.as_u32() - PageId::MIN.as_u32() + 1;
+
     /// Constructs a new immutable page for reading.
     ///
     /// # Panics
@@ -159,13 +161,14 @@ impl fmt::Debug for PageMut<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::page::page_id;
 
     #[repr(align(4096))]
     struct DataArray([u8; Page::SIZE]);
 
     #[test]
     fn test_ref_new() {
-        let id = 42;
+        let id = page_id!(42);
         let data = DataArray([0; Page::SIZE]);
 
         let page = Page::new(id, &data.0);
@@ -177,7 +180,7 @@ mod tests {
 
     #[test]
     fn test_mut_new() {
-        let id = 42;
+        let id = page_id!(42);
         let mut data = DataArray([0; Page::SIZE]);
 
         let page_mut = PageMut::new(id, &mut data.0);
@@ -189,7 +192,7 @@ mod tests {
 
     #[test]
     fn test_mut_with_snapshot() {
-        let id = 42;
+        let id = page_id!(42);
         let snapshot = 1337;
         let mut data = DataArray([0; Page::SIZE]);
 

--- a/src/page/slotted_page.rs
+++ b/src/page/slotted_page.rs
@@ -425,6 +425,7 @@ impl fmt::Debug for SlottedPageMut<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::page::page_id;
 
     #[repr(align(4096))]
     struct DataArray([u8; Page::SIZE]);
@@ -432,7 +433,7 @@ mod tests {
     #[test]
     fn test_insert_get_value() {
         let mut data = DataArray([0; Page::SIZE]);
-        let page = PageMut::with_snapshot(42, 123, &mut data.0);
+        let page = PageMut::with_snapshot(page_id!(42), 123, &mut data.0);
         let mut subtrie_page = SlottedPageMut::try_from(page).unwrap();
 
         let v1 = String::from("hello");
@@ -460,7 +461,7 @@ mod tests {
     #[test]
     fn test_insert_set_value() {
         let mut data = DataArray([0; Page::SIZE]);
-        let page = PageMut::with_snapshot(42, 123, &mut data.0);
+        let page = PageMut::with_snapshot(page_id!(42), 123, &mut data.0);
         let mut subtrie_page = SlottedPageMut::try_from(page).unwrap();
 
         let v1 = String::from("hello");
@@ -480,7 +481,7 @@ mod tests {
     #[test]
     fn test_set_value_same_length() {
         let mut data = DataArray([0; Page::SIZE]);
-        let page = PageMut::with_snapshot(42, 123, &mut data.0);
+        let page = PageMut::with_snapshot(page_id!(42), 123, &mut data.0);
         let mut subtrie_page = SlottedPageMut::try_from(page).unwrap();
 
         let v1 = String::from("hello");
@@ -510,7 +511,7 @@ mod tests {
     #[test]
     fn test_set_value_shrink() {
         let mut data = DataArray([0; Page::SIZE]);
-        let page = PageMut::with_snapshot(42, 123, &mut data.0);
+        let page = PageMut::with_snapshot(page_id!(42), 123, &mut data.0);
         let mut subtrie_page = SlottedPageMut::try_from(page).unwrap();
 
         let v1 = String::from("hello");
@@ -542,7 +543,7 @@ mod tests {
     #[test]
     fn test_set_value_shrink_with_neighbors() {
         let mut data = DataArray([0; Page::SIZE]);
-        let page = PageMut::with_snapshot(42, 123, &mut data.0);
+        let page = PageMut::with_snapshot(page_id!(42), 123, &mut data.0);
         let mut subtrie_page = SlottedPageMut::try_from(page).unwrap();
 
         let v1 = String::from("one");
@@ -602,7 +603,7 @@ mod tests {
     #[test]
     fn test_set_value_grow() {
         let mut data = DataArray([0; Page::SIZE]);
-        let page = PageMut::with_snapshot(42, 123, &mut data.0);
+        let page = PageMut::with_snapshot(page_id!(42), 123, &mut data.0);
         let mut subtrie_page = SlottedPageMut::try_from(page).unwrap();
 
         let v1 = String::from("this");
@@ -632,7 +633,7 @@ mod tests {
     #[test]
     fn test_set_value_grow_with_neighbors() {
         let mut data = DataArray([0; Page::SIZE]);
-        let page = PageMut::with_snapshot(42, 123, &mut data.0);
+        let page = PageMut::with_snapshot(page_id!(42), 123, &mut data.0);
         let mut subtrie_page = SlottedPageMut::try_from(page).unwrap();
 
         let v1 = String::from("one");
@@ -692,7 +693,7 @@ mod tests {
     #[test]
     fn test_allocate_get_delete_cell_pointer() {
         let mut data = DataArray([0; Page::SIZE]);
-        let page = PageMut::with_snapshot(42, 123, &mut data.0);
+        let page = PageMut::with_snapshot(page_id!(42), 123, &mut data.0);
         let mut subtrie_page = SlottedPageMut::try_from(page).unwrap();
         let cell_index = subtrie_page.insert_value(&String::from("foo")).unwrap();
         assert_eq!(cell_index, 0);
@@ -785,7 +786,7 @@ mod tests {
     #[test]
     fn test_allocate_reuse_deleted_space() {
         let mut data = DataArray([0; Page::SIZE]);
-        let page = PageMut::with_snapshot(42, 123, &mut data.0);
+        let page = PageMut::with_snapshot(page_id!(42), 123, &mut data.0);
         let mut subtrie_page = SlottedPageMut::try_from(page).unwrap();
 
         let i0 = subtrie_page.insert_value(&String::from_iter(&['a'; 1020])).unwrap();
@@ -814,7 +815,7 @@ mod tests {
     #[test]
     fn test_allocate_reuse_deleted_spaces() {
         let mut data = DataArray([0; Page::SIZE]);
-        let page = PageMut::with_snapshot(42, 123, &mut data.0);
+        let page = PageMut::with_snapshot(page_id!(42), 123, &mut data.0);
         let mut subtrie_page = SlottedPageMut::try_from(page).unwrap();
 
         // bytes 0-12 are used by the header, and the next 4072 are used by the first 4 cells
@@ -872,7 +873,7 @@ mod tests {
     #[test]
     fn test_defragment_page() {
         let mut data = DataArray([0; Page::SIZE]);
-        let page = PageMut::with_snapshot(42, 123, &mut data.0);
+        let page = PageMut::with_snapshot(page_id!(42), 123, &mut data.0);
         let mut subtrie_page = SlottedPageMut::try_from(page).unwrap();
 
         let i0 = subtrie_page.insert_value(&String::from_iter(&['a'; 814])).unwrap();
@@ -918,7 +919,7 @@ mod tests {
     #[test]
     fn test_defragment_page_cells_out_of_order() {
         let mut data = DataArray([0; Page::SIZE]);
-        let page = PageMut::with_snapshot(42, 123, &mut data.0);
+        let page = PageMut::with_snapshot(page_id!(42), 123, &mut data.0);
         let mut slotted_page = SlottedPageMut::try_from(page).unwrap();
 
         slotted_page.set_num_cells(16);

--- a/src/storage/proofs.rs
+++ b/src/storage/proofs.rs
@@ -57,11 +57,12 @@ impl StorageEngine {
         context: &TransactionContext,
         path: Nibbles,
     ) -> Result<Option<(TrieValue, MultiProof)>, Error> {
-        if context.root_node_page_id == 0 {
-            return Ok(None);
-        }
+        let root_node_page_id = match context.root_node_page_id {
+            None => return Ok(None),
+            Some(page_id) => page_id,
+        };
 
-        let slotted_page = self.get_slotted_page(context, context.root_node_page_id)?;
+        let slotted_page = self.get_slotted_page(context, root_node_page_id)?;
         let mut proof = MultiProof::default();
         let value =
             self.get_value_with_proof_from_page(context, &path, 0, slotted_page, 0, &mut proof)?;

--- a/src/storage/test_utils.rs
+++ b/src/storage/test_utils.rs
@@ -10,15 +10,10 @@ use crate::{
 };
 
 pub(crate) fn create_test_engine(max_pages: u32) -> (StorageEngine, TransactionContext) {
-    let mut meta_manager =
+    let meta_manager =
         MetadataManager::from_file(tempfile::tempfile().expect("failed to create temporary file"))
             .expect("failed to open metadata file");
-    meta_manager.dirty_slot_mut().set_page_count(256);
-
-    let mut page_manager = PageManager::options().max_pages(max_pages).open_temp_file().unwrap();
-    for _ in 0..256 {
-        page_manager.allocate(0).unwrap();
-    }
+    let page_manager = PageManager::options().max_pages(max_pages).open_temp_file().unwrap();
 
     let storage_engine = StorageEngine::new(page_manager, meta_manager);
     let context = storage_engine.write_context();


### PR DESCRIPTION
`PageId` used to be an alias for `u32` with implicit bounds and assumptions. In particular:

* The value 0 was used in some contexts to identify a root page, and in other contexts to identify a null pointer.
* `Location` implicitly assumed that page IDs could not exceed a certain threshold.

The new `PageId` is no longer an alias but an opaque type that documents a verifies the bounds.

Note that now we no longer have root pages, so the value 0 no longer has a meaning other than the one of null pointer. For this reason, `PageId` is now a wrapper around `NonZero<u32>`, which allows `Option<PageId>` to have the same size as `u32`.