### PR TITLE
Enable writing of intermediate nodes

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -59,6 +59,7 @@ pub struct InMemoryChild {
     pub hash: Option<B256>,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InMemoryNode {
     AccountLeaf {


### PR DESCRIPTION
This PR contains

- `InMemoryNode` and `InMemoryChild` types to build recursive in-memory tries
- `build_in_memory_trie` and `build_in_memory_trie_rec` functions to build in-memory trie for `(Nibbles, Option<TrieValue>)` key-value pairs. The `Option` allows for both insertion/update and delete for a key at a given value.
- `set_subtrie` and `merge_in_memory_with_disk` functions which allow merging an in-memory subtrie with an existing on-disk trie at the specified nibbles path.
- tests for building the in-memory trie

Still in progress:

- Hash checking: there is a `HashVerificationMode` enum which will be used to set the level of trust for hashes, either Ignore (always recompute), Check (optimistic hash checking, i.e. verify hashes and use if correct, otherwise recompute), or UnsafeTrust (blindly trust given hashes- currently using for quick tests but could be removed if deemed too risky)
- Tests for `set_subtrie` and `merge_in_memory_with_disk` functions


More context in the [Linear Ticket](https://linear.app/coinbase/issue/CHAIN-988/enable-writing-of-intermediate-non-leaf-trie-nodes)