### PR TITLE
fix: Use Spin Lock for begin_rw

### DIFF
--- a/src/transaction/manager.rs
+++ b/src/transaction/manager.rs
@@ -28,12 +28,13 @@ impl TransactionManager {
     pub fn begin_rw(&mut self, snapshot_id: SnapshotId) -> Result<SnapshotId, TransactionError> {
         // only allow one writable transaction at a time
         loop {
-            if self.has_writer.compare_exchange_weak(
-                false,
-                true,
-                Ordering::Relaxed,
-                Ordering::Relaxed,
-            ).is_ok() { break }
+            if self
+                .has_writer
+                .compare_exchange_weak(false, true, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                break
+            }
         }
 
         self.open_txs.push(snapshot_id - 1);


### PR DESCRIPTION
Reth allows multiple threads to call `begin_rw` and expects the function to "block" if a writer already exists:
https://github.com/paradigmxyz/reth/blob/main/crates/storage/libmdbx-rs/src/environment.rs#L103-L105

We need to implement a similar pattern since Reth will call TrieDB's `begin_rw` mutliple times.