### PR TITLE
Replace `OrphanPages::pop_if()` with a less generic, more optimized function

### DIFF
--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -1878,7 +1878,7 @@ impl StorageEngine {
             .meta_manager
             .lock()
             .orphan_pages()
-            .pop_if(|orphan| orphan.orphaned_at() <= alive_snapshot)
+            .pop(alive_snapshot)
             .map(|orphan| orphan.page_id());
 
         let page_to_return = if let Some(orphaned_page_id) = orphaned_page_id {


### PR DESCRIPTION
The new `OrphanPages::pop()` accepts a `SnapshotId` as an argument (instead of a generic closure) so that it can make more assumptions, thus enabling more optimizations. In particular, the new `pop()` does not scan the full orphan range, but only the boundary elements, because it assumes that if the boundary elements do not fulfill the snasphot requirements, no other elements will.

Even when the assumption fails, eventually all orphan pages will be returned once all active database transactions get committed/discarded. This makes `pop()` *optimistic* and *eventually consistent*.

The problem with the old `OrphanPages::pop_if()` is that a single transaction may mark some pages as orphans, and then try to allocate new pages. If there is an active read transaction, this orphan-then-allocate cycle can cause `pop_if()` to unnecessarily recheck multiple times the same pages that are known to be needed by the read transaction, and therefore cannot be recycled, and if there are tens of thousands of pages involved, this can have a significant performance impact.

Big thanks to @nqd for creating the benchmark that identified this issue.