### PR TITLE
refactor: Hide lifetimes from external crates, support error cloning

### DIFF
--- a/src/meta/error.rs
+++ b/src/meta/error.rs
@@ -17,6 +17,15 @@ pub enum OpenMetadataError {
     IO(io::Error),
 }
 
+impl Clone for OpenMetadataError {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Corrupted => Self::Corrupted,
+            Self::IO(e) => Self::IO(std::io::Error::new(e.kind(), e.to_string())),
+        }
+    }
+}
+
 impl fmt::Display for OpenMetadataError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/src/node.rs
+++ b/src/node.rs
@@ -53,7 +53,7 @@ pub enum Node {
     },
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum NodeError {
     ChildrenUnsupported,
     MaxPrefixLengthExceeded,

--- a/src/page/manager.rs
+++ b/src/page/manager.rs
@@ -20,3 +20,22 @@ pub enum PageError {
     InvalidPageContents(PageId),
     // TODO: add more errors here for other cases.
 }
+
+impl Clone for PageError {
+    fn clone(&self) -> Self {
+        match self {
+            Self::PageNotFound(id) => Self::PageNotFound(*id),
+            Self::PageOccupied(id) => Self::PageOccupied(*id),
+            Self::PageDirty(id) => Self::PageDirty(*id),
+            Self::PageLimitReached => Self::PageLimitReached,
+            Self::InvalidRootPage(id) => Self::InvalidRootPage(*id),
+            Self::InvalidCellPointer => Self::InvalidCellPointer,
+            Self::NoFreeCells => Self::NoFreeCells,
+            Self::PageIsFull => Self::PageIsFull,
+            Self::PageSplitLimitReached => Self::PageSplitLimitReached,
+            Self::IO(e) => Self::IO(std::io::Error::new(e.kind(), e.to_string())),
+            Self::InvalidValue => Self::InvalidValue,
+            Self::InvalidPageContents(id) => Self::InvalidPageContents(*id),
+        }
+    }
+}

--- a/src/page/slotted_page.rs
+++ b/src/page/slotted_page.rs
@@ -68,7 +68,7 @@ impl SlottedPage<'_> {
     }
 
     // Returns the cell pointer at the given index.
-    fn get_cell_pointer(&self, index: u8) -> Result<CellPointer, PageError> {
+    fn get_cell_pointer(&self, index: u8) -> Result<CellPointer<'_>, PageError> {
         if index >= self.num_cells() {
             return Err(PageError::InvalidCellPointer);
         }
@@ -83,7 +83,7 @@ impl SlottedPage<'_> {
         self.page.contents()[0]
     }
 
-    fn cell_pointers_iter(&self) -> impl Iterator<Item = CellPointer> {
+    fn cell_pointers_iter(&self) -> impl Iterator<Item = CellPointer<'_>> {
         self.page.contents()[1..=CELL_POINTER_SIZE * self.num_cells() as usize]
             .chunks(CELL_POINTER_SIZE)
             .map(|chunk| chunk.try_into().unwrap())
@@ -244,7 +244,11 @@ impl<'a> SlottedPageMut<'a> {
 
     // Allocates a cell pointer at the given index with the given length and returns the cell
     // pointer.
-    fn allocate_cell_pointer(&mut self, index: u8, length: u16) -> Result<CellPointer, PageError> {
+    fn allocate_cell_pointer(
+        &mut self,
+        index: u8,
+        length: u16,
+    ) -> Result<CellPointer<'_>, PageError> {
         match self.find_available_slot(index, length)? {
             Some(offset) => {
                 let num_cells = self.num_cells();
@@ -397,7 +401,7 @@ impl<'a> SlottedPageMut<'a> {
         index: u8,
         offset: u16,
         length: u16,
-    ) -> Result<CellPointer, PageError> {
+    ) -> Result<CellPointer<'_>, PageError> {
         let start_index = 1 + CELL_POINTER_SIZE * (index as usize);
         let end_index = start_index + CELL_POINTER_SIZE;
         let data = &mut self.page.contents_mut()[start_index..end_index];

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -34,21 +34,21 @@ impl TransactionKind for RO {}
 // Compile-time assertion to ensure that `Transaction` is `Send`
 const _: fn() = || {
     fn consumer<T: Send>() {}
-    consumer::<Transaction<'_, RO>>();
-    consumer::<Transaction<'_, RW>>();
+    consumer::<Transaction<RO>>();
+    consumer::<Transaction<RW>>();
 };
 
 #[derive(Debug)]
-pub struct Transaction<'tx, K: TransactionKind> {
+pub struct Transaction<K: TransactionKind> {
     committed: bool,
     context: TransactionContext,
-    database: &'tx Database,
+    database: Database,
     pending_changes: HashMap<Nibbles, Option<TrieValue>>,
     _marker: std::marker::PhantomData<K>,
 }
 
-impl<'tx, K: TransactionKind> Transaction<'tx, K> {
-    pub(crate) fn new(context: TransactionContext, database: &'tx Database) -> Self {
+impl<K: TransactionKind> Transaction<K> {
+    pub(crate) fn new(context: TransactionContext, database: Database) -> Self {
         Self {
             committed: false,
             context,
@@ -62,9 +62,13 @@ impl<'tx, K: TransactionKind> Transaction<'tx, K> {
         &mut self,
         address_path: AddressPath,
     ) -> Result<Option<Account>, TransactionError> {
-        let account =
-            self.database.storage_engine.get_account(&mut self.context, address_path).unwrap();
-        self.database.update_metrics_ro(&self.context);
+        let account = self
+            .database
+            .inner
+            .storage_engine
+            .get_account(&mut self.context, address_path)
+            .unwrap();
+        self.database.inner.update_metrics_ro(&self.context);
         Ok(account)
     }
 
@@ -72,9 +76,13 @@ impl<'tx, K: TransactionKind> Transaction<'tx, K> {
         &mut self,
         storage_path: StoragePath,
     ) -> Result<Option<StorageValue>, TransactionError> {
-        let storage_slot =
-            self.database.storage_engine.get_storage(&mut self.context, storage_path).unwrap();
-        self.database.update_metrics_ro(&self.context);
+        let storage_slot = self
+            .database
+            .inner
+            .storage_engine
+            .get_storage(&mut self.context, storage_path)
+            .unwrap();
+        self.database.inner.update_metrics_ro(&self.context);
         Ok(storage_slot)
     }
 
@@ -88,6 +96,7 @@ impl<'tx, K: TransactionKind> Transaction<'tx, K> {
     ) -> Result<Option<AccountProof>, TransactionError> {
         let result = self
             .database
+            .inner
             .storage_engine
             .get_account_with_proof(&self.context, address_path)
             .unwrap();
@@ -100,6 +109,7 @@ impl<'tx, K: TransactionKind> Transaction<'tx, K> {
     ) -> Result<Option<AccountProof>, TransactionError> {
         let result = self
             .database
+            .inner
             .storage_engine
             .get_storage_with_proof(&self.context, storage_path)
             .unwrap();
@@ -117,6 +127,7 @@ impl<'tx, K: TransactionKind> Transaction<'tx, K> {
         verbosity_level: u8,
     ) -> Result<(), TransactionError> {
         self.database
+            .inner
             .storage_engine
             .print_path(&self.context, address_path.to_nibbles(), output_file, verbosity_level)
             .unwrap();
@@ -130,6 +141,7 @@ impl<'tx, K: TransactionKind> Transaction<'tx, K> {
         verbosity_level: u8,
     ) -> Result<(), TransactionError> {
         self.database
+            .inner
             .storage_engine
             .print_path(&self.context, &storage_path.full_path(), output_file, verbosity_level)
             .unwrap();
@@ -137,7 +149,7 @@ impl<'tx, K: TransactionKind> Transaction<'tx, K> {
     }
 }
 
-impl Transaction<'_, RW> {
+impl Transaction<RW> {
     pub fn set_account(
         &mut self,
         address_path: AddressPath,
@@ -161,13 +173,17 @@ impl Transaction<'_, RW> {
             self.pending_changes.drain().collect::<Vec<(Nibbles, Option<TrieValue>)>>();
 
         if !changes.is_empty() {
-            self.database.storage_engine.set_values(&mut self.context, changes.as_mut()).unwrap();
+            self.database
+                .inner
+                .storage_engine
+                .set_values(&mut self.context, changes.as_mut())
+                .unwrap();
         }
 
-        let mut transaction_manager = self.database.transaction_manager.lock();
-        self.database.storage_engine.commit(&self.context).unwrap();
+        let mut transaction_manager = self.database.inner.transaction_manager.lock();
+        self.database.inner.storage_engine.commit(&self.context).unwrap();
 
-        self.database.update_metrics_rw(&self.context);
+        self.database.inner.update_metrics_rw(&self.context);
 
         transaction_manager.remove_tx(self.context.snapshot_id, true);
 
@@ -176,9 +192,9 @@ impl Transaction<'_, RW> {
     }
 
     pub fn rollback(mut self) -> Result<(), TransactionError> {
-        self.database.storage_engine.rollback(&self.context).unwrap();
+        self.database.inner.storage_engine.rollback(&self.context).unwrap();
 
-        let mut transaction_manager = self.database.transaction_manager.lock();
+        let mut transaction_manager = self.database.inner.transaction_manager.lock();
         transaction_manager.remove_tx(self.context.snapshot_id, true);
 
         self.committed = false;
@@ -186,9 +202,9 @@ impl Transaction<'_, RW> {
     }
 }
 
-impl Transaction<'_, RO> {
+impl Transaction<RO> {
     pub fn commit(mut self) -> Result<(), TransactionError> {
-        let mut transaction_manager = self.database.transaction_manager.lock();
+        let mut transaction_manager = self.database.inner.transaction_manager.lock();
         transaction_manager.remove_tx(self.context.snapshot_id, false);
 
         self.committed = true;
@@ -196,7 +212,7 @@ impl Transaction<'_, RO> {
     }
 }
 
-impl<K: TransactionKind> Drop for Transaction<'_, K> {
+impl<K: TransactionKind> Drop for Transaction<K> {
     fn drop(&mut self) {
         // TODO: panic if the transaction is not committed
     }

--- a/src/transaction/error.rs
+++ b/src/transaction/error.rs
@@ -1,6 +1,6 @@
 use std::{error::Error, fmt};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TransactionError;
 
 impl fmt::Display for TransactionError {


### PR DESCRIPTION
Improve usability of TrieDB as a crate by making the following external-facing changes:
* Remove lifetimes from Transactions, by instead holding an `Arc` of a database handle
* Allow error types to be clonable

This re-introduces `DatabaseInner`, with `Database` simply holding an `Arc` of the inner struct.

Replaces #108 