### PR TITLE
chore: Update most dependencies to latest versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,25 +4,25 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-alloy-primitives = { version = "0.8.25", features = ["arbitrary", "rand"] }
-alloy-rlp = "0.3.11"
-alloy-trie = { version = "0.7.9", features = ["arbitrary", "ethereum"] }
+alloy-primitives = { version = "1.2.1", features = ["arbitrary", "rand"] }
+alloy-rlp = "0.3.12"
+alloy-trie = { version = "0.8.1", features = ["arbitrary", "ethereum"] }
 arrayvec = "0.7.6"
 memmap2 = "0.9.5"
-proptest = "1.6.0"
-proptest-derive = "0.5.1"
+proptest = "1.7.0"
+proptest-derive = "0.6.0"
 sealed = "0.6.0"
 metrics-derive = "0.1.0"
-metrics = "0.24.1"
+metrics = "0.24.2"
 zerocopy = { version = "0.8.24", features = ["derive"] }
-parking_lot = { version = "0.12.3", features = ["send_guard"] }
+parking_lot = { version = "0.12.4", features = ["send_guard"] }
 fxhash = "0.2.1"
 static_assertions = "1.1.0"
 
 [dev-dependencies]
-criterion = "0.5"
+criterion = "0.6.0"
 tempdir = "0.3.7"
-rand = "0.8.5"
+rand = "0.9.1"
 walkdir = "2"
 serde_json = "1.0.140"
 tempfile = "3.19.1"

--- a/benches/crud_benchmarks.rs
+++ b/benches/crud_benchmarks.rs
@@ -301,7 +301,7 @@ fn bench_mixed_operations(c: &mut Criterion) {
             |db| {
                 let mut tx = db.begin_rw().unwrap();
                 for i in 0..BATCH_SIZE {
-                    let op = eoa_rng.gen_range(0..=7);
+                    let op = eoa_rng.random_range(0..=7);
                     match op {
                         0 => {
                             // Read

--- a/src/database.rs
+++ b/src/database.rs
@@ -177,13 +177,13 @@ impl Database {
         let root_node_page_id = active_slot.root_node_page_id();
         let orphaned_page_list = meta_manager.orphan_pages().iter().collect::<Vec<_>>();
 
-        writeln!(buf, "Root Node Page ID: {:?}", root_node_page_id).expect("write failed");
+        writeln!(buf, "Root Node Page ID: {root_node_page_id:?}").expect("write failed");
 
         //root subtrie pageID
-        writeln!(buf, "Total Page Count: {:?}", page_count).expect("write failed");
+        writeln!(buf, "Total Page Count: {page_count:?}").expect("write failed");
 
         //orphaned pages list (grouped by page)
-        writeln!(buf, "Orphaned Pages: {:?}", orphaned_page_list).expect("write failed");
+        writeln!(buf, "Orphaned Pages: {orphaned_page_list:?}").expect("write failed");
 
         Ok(())
     }

--- a/src/page/slotted_page.rs
+++ b/src/page/slotted_page.rs
@@ -68,7 +68,7 @@ impl SlottedPage<'_> {
     }
 
     // Returns the cell pointer at the given index.
-    fn get_cell_pointer(&self, index: u8) -> Result<CellPointer, PageError> {
+    fn get_cell_pointer(&self, index: u8) -> Result<CellPointer<'_>, PageError> {
         if index >= self.num_cells() {
             return Err(PageError::InvalidCellPointer);
         }
@@ -83,7 +83,7 @@ impl SlottedPage<'_> {
         self.page.contents()[0]
     }
 
-    fn cell_pointers_iter(&self) -> impl Iterator<Item = CellPointer> {
+    fn cell_pointers_iter(&self) -> impl Iterator<Item = CellPointer<'_>> {
         self.page.contents()[1..=CELL_POINTER_SIZE * self.num_cells() as usize]
             .chunks(CELL_POINTER_SIZE)
             .map(|chunk| chunk.try_into().unwrap())
@@ -244,7 +244,11 @@ impl<'a> SlottedPageMut<'a> {
 
     // Allocates a cell pointer at the given index with the given length and returns the cell
     // pointer.
-    fn allocate_cell_pointer(&mut self, index: u8, length: u16) -> Result<CellPointer, PageError> {
+    fn allocate_cell_pointer(
+        &mut self,
+        index: u8,
+        length: u16,
+    ) -> Result<CellPointer<'_>, PageError> {
         match self.find_available_slot(index, length)? {
             Some(offset) => {
                 let num_cells = self.num_cells();
@@ -397,7 +401,7 @@ impl<'a> SlottedPageMut<'a> {
         index: u8,
         offset: u16,
         length: u16,
-    ) -> Result<CellPointer, PageError> {
+    ) -> Result<CellPointer<'_>, PageError> {
         let start_index = 1 + CELL_POINTER_SIZE * (index as usize);
         let end_index = start_index + CELL_POINTER_SIZE;
         let data = &mut self.page.contents_mut()[start_index..end_index];

--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -1049,21 +1049,14 @@ impl StorageEngine {
         } else if children.len() == 1 {
             // Merge branch with its only child
             let (idx, ptr) = children[0];
-            return self.merge_branch_with_only_child(
-                context,
-                slotted_page,
-                page_index,
-                node,
-                idx,
-                ptr,
-            );
+            self.merge_branch_with_only_child(context, slotted_page, page_index, node, idx, ptr)
         } else {
             // Normal branch node with multiple children
             let rlp_node = node.as_rlp_node();
-            return Ok(PointerChange::Update(Pointer::new(
+            Ok(PointerChange::Update(Pointer::new(
                 node_location(slotted_page.id(), page_index),
                 rlp_node,
-            )));
+            )))
         }
     }
 
@@ -1397,7 +1390,7 @@ impl StorageEngine {
                     // child is on different page, and we are only printing the current page
                     if new_slotted_page.id() != slotted_page.id() && !print_whole_db {
                         let child_page_id = direct_child.location().page_id().unwrap();
-                        writeln!(buf, "{}Child on new page: {:?}", new_indent, child_page_id)?;
+                        writeln!(buf, "{new_indent}Child on new page: {child_page_id:?}")?;
                         Ok(())
                     } else {
                         self.print_page_helper(
@@ -1410,7 +1403,7 @@ impl StorageEngine {
                         )
                     }
                 } else {
-                    writeln!(buf, "{}No direct child", new_indent)?;
+                    writeln!(buf, "{new_indent}No direct child")?;
                     Ok(())
                 }
             }
@@ -1427,7 +1420,7 @@ impl StorageEngine {
                     // child is on new page, and we are only printing the current page
                     if new_slotted_page.id() != slotted_page.id() && !print_whole_db {
                         let child_page_id = child.location().page_id().unwrap();
-                        writeln!(buf, "{}Child on new page: {:?}", new_indent, child_page_id)?;
+                        writeln!(buf, "{new_indent}Child on new page: {child_page_id:?}")?;
                         return Ok(());
                     } else {
                         self.print_page_helper(
@@ -1471,14 +1464,14 @@ impl StorageEngine {
             0 => (),
             1 => {
                 //verbose; print page ID and nodes accessed from page
-                writeln!(buf, "\nNODES ACCESSED FROM PAGE {}\n", page_id)?;
+                writeln!(buf, "\nNODES ACCESSED FROM PAGE {page_id}\n")?;
             }
             2 => {
                 //extra verbose; print page ID, nodes accessed from page, and page contents
-                writeln!(buf, "PAGE: {}\n", page_id)?;
+                writeln!(buf, "PAGE: {page_id}\n")?;
 
                 self.print_page(context, &mut buf, Some(page_id))?;
-                writeln!(buf, "\nNODES ACCESSED FROM PAGE {}:", page_id)?;
+                writeln!(buf, "\nNODES ACCESSED FROM PAGE {page_id}:")?;
             }
             _ => return Err(Error::DebugError("Invalid verbosity level".to_string())),
         }
@@ -1609,7 +1602,7 @@ impl StorageEngine {
                         )?;
                     }
                     _ => {
-                        writeln!(buf, "{}AccountLeaf: no value ", indent)?;
+                        writeln!(buf, "{indent}AccountLeaf: no value ")?;
                     }
                 };
                 Ok(())
@@ -1620,12 +1613,11 @@ impl StorageEngine {
                         let str_prefix = alloy_primitives::hex::encode(prefix.pack());
                         writeln!(
                             buf,
-                            "{}StorageLeaf: storage: {:?}, prefix: {}",
-                            indent, strg, str_prefix
+                            "{indent}StorageLeaf: storage: {strg:?}, prefix: {str_prefix}"
                         )?;
                     }
                     _ => {
-                        writeln!(buf, "{}StorageLeaf: no value", indent)?;
+                        writeln!(buf, "{indent}StorageLeaf: no value")?;
                     }
                 };
                 Ok(())
@@ -1655,7 +1647,7 @@ impl StorageEngine {
 
         self.debug_statistics_helper(context, slotted_page, 0, 1, 1, &mut stats)?;
 
-        writeln!(buf, "Page Statistics: {:?}", stats)?;
+        writeln!(buf, "Page Statistics: {stats:?}")?;
         Ok(())
     }
 
@@ -2259,7 +2251,7 @@ mod tests {
             let account = random_test_account(&mut rng);
             let mut storage = Vec::new();
             if idx % 10 == 0 {
-                for _ in 0..rng.gen_range(1..25) {
+                for _ in 0..rng.random_range(1..25) {
                     let slot = StorageKey::random_with(&mut rng);
                     storage.push((slot, StorageValue::from(rng.next_u64())));
                 }
@@ -3057,12 +3049,12 @@ mod tests {
             let mut nibbles = [0u8; 64];
             // Generate random nibbles
             for nibble in &mut nibbles {
-                *nibble = rng.gen_range(0..16) as u8;
+                *nibble = rng.random_range(0..16) as u8;
             }
 
             let path = AddressPath::new(Nibbles::from_nibbles(nibbles));
-            let balance = rng.gen_range(0..1_000_000);
-            let nonce = rng.gen_range(0..100);
+            let balance = rng.random_range(0..1_000_000);
+            let nonce = rng.random_range(0..100);
             let account = create_test_account(balance, nonce);
             accounts.push((path, account));
         }
@@ -3133,8 +3125,8 @@ mod tests {
         for (i, (path, _)) in accounts.iter().enumerate() {
             if i % 5 == 0 {
                 // Update every 5th account
-                let new_balance = rng.gen_range(0..1_000_000);
-                let new_nonce = rng.gen_range(0..100);
+                let new_balance = rng.random_range(0..1_000_000);
+                let new_nonce = rng.random_range(0..100);
                 let new_account = create_test_account(new_balance, new_nonce);
 
                 updates.push((i, path.clone(), new_account));


### PR DESCRIPTION
This notably does not upgrade `alloy-trie` to `0.9.0`, as this includes backwards-incompatible changes to the `Nibbles` type