### PR TITLE
Fix clippy warnings

### DIFF
--- a/benches/benchmark_common.rs
+++ b/benches/benchmark_common.rs
@@ -44,7 +44,7 @@ pub fn get_base_database(
         let file_name =
             std::env::var("FILE_NAME").expect("FILE_NAME must be set when using BASE_DIR");
         let main_file_name = file_name.to_string();
-        let meta_file_name = format!("{}.meta", file_name);
+        let meta_file_name = format!("{file_name}.meta");
         let file_name_path = Path::new(&base_dir).join(&main_file_name);
         let meta_file_name_path = Path::new(&base_dir).join(&meta_file_name);
 

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -836,8 +836,7 @@ mod tests {
                 ),
                 Some(orphan) => assert!(
                     expected.remove(&orphan),
-                    "metadata manager returned an orphan page ({:?}) that is not available",
-                    orphan
+                    "metadata manager returned an orphan page ({orphan:?}) that is not available"
                 ),
             }
         }

--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -2932,7 +2932,7 @@ mod tests {
         // Ensure there are no duplicate paths
         let mut unique_paths = std::collections::HashSet::new();
         for (path, _) in &accounts {
-            assert!(unique_paths.insert(path.clone()), "Duplicate path found: {:?}", path);
+            assert!(unique_paths.insert(path.clone()), "Duplicate path found: {path:?}");
         }
 
         // Insert all accounts
@@ -2951,8 +2951,7 @@ mod tests {
             assert_eq!(
                 retrieved_account,
                 Some(expected_account.clone()),
-                "Account mismatch for path: {:?}",
-                path
+                "Account mismatch for path: {path:?}"
             );
         }
 
@@ -2979,8 +2978,7 @@ mod tests {
             assert_eq!(
                 retrieved_account,
                 Some(expected_account.clone()),
-                "Account mismatch after split for path: {:?}",
-                path
+                "Account mismatch after split for path: {path:?}"
             );
         }
 
@@ -3123,7 +3121,7 @@ mod tests {
 
         // Prepare updates for some existing accounts
         for (i, (path, _)) in accounts.iter().enumerate() {
-            if i % 5 == 0 {
+            if i.is_multiple_of(5) {
                 // Update every 5th account
                 let new_balance = rng.random_range(0..1_000_000);
                 let new_nonce = rng.random_range(0..100);

--- a/tests/ethereum_execution_spec.rs
+++ b/tests/ethereum_execution_spec.rs
@@ -29,8 +29,8 @@ fn run_ethereum_execution_spec_state_tests() {
         let test_cases = state_test_case.as_object().unwrap();
         for (test_case_name, test_case) in test_cases.iter() {
             let tmp_dir = TempDir::new("ethereum_execution_spec_state_tests").unwrap();
-            println!("running test: {:?}", test_case_name);
-            let database_file_name = &format!("test_db_{}", test_case_name)
+            println!("running test: {test_case_name:?}");
+            let database_file_name = &format!("test_db_{test_case_name}")
                 .as_str()
                 .replace("/", "_")[0..min(test_case_name.len(), 100)];
             let file_path = tmp_dir.path().join(database_file_name).to_str().unwrap().to_owned();
@@ -166,8 +166,7 @@ fn run_ethereum_execution_spec_state_tests() {
             assert_eq!(
                 expected_state_root,
                 test_database.state_root(),
-                "failed test: {}",
-                test_case_name
+                "failed test: {test_case_name}"
             );
 
             tmp_dir.close().unwrap();


### PR DESCRIPTION
These are warnings that were brought in in the latest version of Rust, and are making PR workflows fail.