### PR TITLE
add `max_pages` to DatabaseOptions

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -82,7 +82,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "983d99aa81f586cef9dae38443245e585840fcf0fc58b09aee0b1f27aed1d500"
 dependencies = [
- "alloy-primitives 0.8.25",
+ "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
  "arrayvec",
@@ -433,8 +433,8 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 name = "cli"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 0.8.25",
- "alloy-trie 0.7.9",
+ "alloy-primitives",
+ "alloy-trie",
  "clap",
  "hex",
  "triedb",
@@ -1697,12 +1697,11 @@ dependencies = [
 name = "triedb"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives",
  "alloy-rlp",
- "alloy-trie 0.8.1",
+ "alloy-trie",
  "arrayvec",
  "fxhash",
- "log",
  "memmap2",
  "metrics",
  "metrics-derive",


### PR DESCRIPTION
Closes https://linear.app/coinbase/issue/CHAIN-898/triedb-configuration-system

## Overview

Be able to let an outside user of the `Database` specify `max_pages` for `PageManagerOptions`

Even though this already uses different default values depending if it's test or not, this setting will be helpful later when importing with reth since it uses the standard (larger) max page count, and running too many of these tests in parallel will lead to a memory allocation error

Usage

```rust
PageManager::options()
    .max_pages(opts.max_pages)
```

## Test Plan

- All existing unit tests pass
- CI 