### PR TITLE
Increase the "measurement time" for all benchmarks to 30 seconds

### DIFF
--- a/benches/crud_benchmarks.rs
+++ b/benches/crud_benchmarks.rs
@@ -18,10 +18,9 @@ mod benchmark_common;
 
 use alloy_primitives::{StorageKey, StorageValue, U256};
 use alloy_trie::{EMPTY_ROOT_HASH, KECCAK_EMPTY};
-// use benchmark_common::{generate_random_address, BATCH_SIZE};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use rand::prelude::*;
-use std::{fs, io, path::Path};
+use std::{fs, io, path::Path, time::Duration};
 use tempdir::TempDir;
 use triedb::{
     account::Account,
@@ -66,6 +65,7 @@ fn bench_account_reads(c: &mut Criterion) {
         (0..BATCH_SIZE).map(|_| generate_random_address(&mut rng)).collect();
 
     group.throughput(criterion::Throughput::Elements(BATCH_SIZE as u64));
+    group.measurement_time(Duration::from_secs(30));
     group.bench_function(BenchmarkId::new("eoa_reads", BATCH_SIZE), |b| {
         b.iter_with_setup(
             || {
@@ -100,6 +100,7 @@ fn bench_account_inserts(c: &mut Criterion) {
         (0..BATCH_SIZE).map(|_| generate_random_address(&mut rng)).collect();
 
     group.throughput(criterion::Throughput::Elements(BATCH_SIZE as u64));
+    group.measurement_time(Duration::from_secs(30));
     group.bench_function(BenchmarkId::new("eoa_inserts", BATCH_SIZE), |b| {
         b.iter_with_setup(
             || {
@@ -137,6 +138,7 @@ fn bench_account_inserts_loop(c: &mut Criterion) {
         (0..BATCH_SIZE).map(|_| generate_random_address(&mut rng)).collect();
 
     group.throughput(criterion::Throughput::Elements(BATCH_SIZE as u64));
+    group.measurement_time(Duration::from_secs(30));
     group.bench_function(BenchmarkId::new("eoa_inserts_loop", BATCH_SIZE), |b| {
         b.iter_with_setup(
             || {
@@ -184,6 +186,7 @@ fn bench_account_updates(c: &mut Criterion) {
         (0..BATCH_SIZE).map(|_| generate_random_address(&mut rng)).collect();
 
     group.throughput(criterion::Throughput::Elements(BATCH_SIZE as u64));
+    group.measurement_time(Duration::from_secs(30));
     group.bench_function(BenchmarkId::new("eoa_updates", BATCH_SIZE), |b| {
         b.iter_with_setup(
             || {
@@ -220,6 +223,7 @@ fn bench_account_deletes(c: &mut Criterion) {
         (0..BATCH_SIZE).map(|_| generate_random_address(&mut rng)).collect();
 
     group.throughput(criterion::Throughput::Elements(BATCH_SIZE as u64));
+    group.measurement_time(Duration::from_secs(30));
     group.bench_function(BenchmarkId::new("eoa_deletes", BATCH_SIZE), |b| {
         b.iter_with_setup(
             || {
@@ -290,6 +294,7 @@ fn bench_mixed_operations(c: &mut Criterion) {
     }
 
     group.throughput(criterion::Throughput::Elements(BATCH_SIZE as u64));
+    group.measurement_time(Duration::from_secs(30));
     group.bench_function(BenchmarkId::new("mixed_operations", BATCH_SIZE), |b| {
         b.iter_with_setup(
             || {
@@ -390,6 +395,7 @@ fn bench_storage_reads(c: &mut Criterion) {
     let storage_paths_values = generate_storage_paths_values(&addresses, total_storage_per_address);
 
     group.throughput(criterion::Throughput::Elements(BATCH_SIZE as u64));
+    group.measurement_time(Duration::from_secs(30));
     group.bench_function(BenchmarkId::new("storage_reads", BATCH_SIZE), |b| {
         b.iter_with_setup(
             || {
@@ -427,6 +433,7 @@ fn bench_storage_inserts(c: &mut Criterion) {
     let storage_paths_values = generate_storage_paths_values(&addresses, total_storage_per_address);
 
     group.throughput(criterion::Throughput::Elements(BATCH_SIZE as u64));
+    group.measurement_time(Duration::from_secs(30));
     group.bench_function(BenchmarkId::new("storage_inserts", BATCH_SIZE), |b| {
         b.iter_with_setup(
             || {
@@ -470,6 +477,7 @@ fn bench_storage_updates(c: &mut Criterion) {
     let storage_paths_values = generate_storage_paths_values(&addresses, total_storage_per_address);
 
     group.throughput(criterion::Throughput::Elements(BATCH_SIZE as u64));
+    group.measurement_time(Duration::from_secs(30));
     group.bench_function(BenchmarkId::new("storage_updates", BATCH_SIZE), |b| {
         b.iter_with_setup(
             || {
@@ -508,6 +516,7 @@ fn bench_storage_deletes(c: &mut Criterion) {
     let storage_paths_values = generate_storage_paths_values(&addresses, total_storage_per_address);
 
     group.throughput(criterion::Throughput::Elements(BATCH_SIZE as u64));
+    group.measurement_time(Duration::from_secs(30));
     group.bench_function(BenchmarkId::new("storage_deletes", BATCH_SIZE), |b| {
         b.iter_with_setup(
             || {

--- a/benches/proof_benchmarks.rs
+++ b/benches/proof_benchmarks.rs
@@ -7,6 +7,7 @@ use benchmark_common::{
 };
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use rand::prelude::*;
+use std::time::Duration;
 use triedb::{path::AddressPath, Database};
 
 fn bench_account_get_proof(c: &mut Criterion) {
@@ -23,6 +24,7 @@ fn bench_account_get_proof(c: &mut Criterion) {
         (0..BATCH_SIZE).map(|_| generate_random_address(&mut rng)).collect();
 
     group.throughput(criterion::Throughput::Elements(BATCH_SIZE as u64));
+    group.measurement_time(Duration::from_secs(30));
     group.bench_function(BenchmarkId::new("account_get_proof", BATCH_SIZE), |b| {
         b.iter_with_setup(
             || {
@@ -60,6 +62,7 @@ fn bench_storage_get_proof(c: &mut Criterion) {
     let storage_paths_values = generate_storage_paths_values(&addresses, total_storage_per_address);
 
     group.throughput(criterion::Throughput::Elements(BATCH_SIZE as u64));
+    group.measurement_time(Duration::from_secs(30));
     group.bench_function(BenchmarkId::new("storage_get_proof", BATCH_SIZE), |b| {
         b.iter_with_setup(
             || {


### PR DESCRIPTION
Running benchmarks on my laptop always results in warning messages like this one:

```
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 22.1s, or reduce sample count to 20.
```

This makes benchmarks less reliable, and comparing benchmark results can lead to wrong conclusions. This change makes benchmarks take longer, but now results are consistent across runs.