### PR TITLE
fix: Fix bug leading to double-orphaning of some pages

### DIFF
--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -355,14 +355,7 @@ impl StorageEngine {
             );
 
             match result {
-                // This case means the root node was deleted so orphan this page.
-                // TODO: this page could actually be reallocated in the same transaction,
-                // but this would require adding the page_id to a pending buffer. It would
-                // still be orphaned if unused by the end of the transaction.
-                Ok(PointerChange::Delete) => {
-                    self.orphan_page(context, page_id)?;
-                    return Ok(PointerChange::Delete);
-                }
+                Ok(PointerChange::Delete) => return Ok(PointerChange::Delete),
                 Ok(PointerChange::None) => return Ok(PointerChange::None),
                 Ok(PointerChange::Update(pointer)) => return Ok(PointerChange::Update(pointer)),
                 // In the case of a page split, re-attempt the operation from scratch. This ensures
@@ -1046,6 +1039,10 @@ impl StorageEngine {
         if children.is_empty() {
             // Delete empty branch node
             slotted_page.delete_value(page_index)?;
+            // If we're the root node, orphan our page
+            if page_index == 0 {
+                self.orphan_page(context, slotted_page.id())?;
+            }
             Ok(PointerChange::Delete)
         } else if children.len() == 1 {
             // Merge branch with its only child
@@ -1975,7 +1972,7 @@ mod tests {
     };
     use proptest::prelude::*;
     use rand::{rngs::StdRng, seq::SliceRandom, Rng, RngCore, SeedableRng};
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
 
     #[test]
     fn test_allocate_get_mut_clone() {
@@ -4143,5 +4140,103 @@ mod tests {
 
             assert_eq!(shortest_common_prefix_length, shortest_from_full_iteration);
         }
+    }
+
+    #[test]
+    fn test_double_orphan_bug_repro() {
+        let (storage_engine, mut context) = create_test_engine(10_000);
+
+        // Step 1: Create a target account that will live alone on its own page
+        let target_address = address!("1111111111111111111111111111111111111111");
+        let target_account = create_test_account(1, 100);
+
+        // Allocate a dedicated page for our target account (this will be page 1)
+        let target_page = storage_engine.allocate_page(&mut context).unwrap();
+        let target_page_id = target_page.id();
+        let mut target_slotted_page = SlottedPageMut::try_from(target_page).unwrap();
+
+        // Create the target account node and insert it at index 0 (root of the page)
+        let target_path = AddressPath::for_address(target_address);
+        let target_node = Node::new_leaf(
+            target_path.to_nibbles().slice(1..),
+            &TrieValue::Account(target_account.clone()),
+        )
+        .unwrap();
+        let target_node_index = target_slotted_page.insert_value(&target_node).unwrap();
+        assert_eq!(target_node_index, 0, "Target node should be at root of its page");
+
+        drop(target_slotted_page); // Release the page
+
+        // Step 2: Create a parent branch node on a different page that points to our target
+        let parent_page = storage_engine.allocate_page(&mut context).unwrap();
+        let parent_page_id = parent_page.id();
+        context.root_node_page_id = Some(parent_page_id); // Make this the root
+        let mut parent_slotted_page = SlottedPageMut::try_from(parent_page).unwrap();
+
+        // Create a branch node with a short prefix that will point to our target
+        let mut parent_branch = Node::new_branch(Nibbles::new()).unwrap();
+
+        // Set the target as a child of the parent branch
+        // Use the first nibble of the target address to determine the branch index
+        let target_nibbles = target_path.to_nibbles();
+        let branch_index = target_nibbles[0];
+
+        // Create a pointer to the target node with the remaining path
+        let remaining_path = target_nibbles.slice(1..);
+        let target_node_for_pointer =
+            Node::new_leaf(remaining_path, &TrieValue::Account(target_account.clone())).unwrap();
+        let target_pointer_with_path =
+            Pointer::new(Location::from(target_page_id), target_node_for_pointer.to_rlp_node());
+
+        parent_branch.set_child(branch_index, target_pointer_with_path).unwrap();
+
+        // Insert the parent branch at index 0 (root of parent page)
+        let parent_node_index = parent_slotted_page.insert_value(&parent_branch).unwrap();
+        assert_eq!(parent_node_index, 0, "Parent branch should be at root of its page");
+
+        drop(parent_slotted_page); // Release the page
+
+        // Step 3: Commit this initial state to establish baseline snapshots
+        storage_engine.commit(&context).unwrap();
+        context = storage_engine.write_context();
+
+        // Step 4: Count orphan pages before the delete operation
+        let orphan_count_before = {
+            let mut meta_manager = storage_engine.meta_manager.lock();
+            meta_manager.orphan_pages().len()
+        };
+        assert_eq!(orphan_count_before, 0, "Expected no orphan pages before the delete operation");
+
+        // Step 5: Delete the target account, causing the parent and target pages to be orphaned, as
+        // well as their mutable clones. Both pages should be cloned as they are iterated
+        // over, but then the clones should be deleted in the cleanup phase as their
+        // root nodes are deleted.
+        storage_engine.set_values(&mut context, vec![(target_path.into(), None)].as_mut()).unwrap();
+
+        // Step 6: Check for duplicate orphan entries
+        let mut meta_manager = storage_engine.meta_manager.lock();
+        let orphan_pages = meta_manager.orphan_pages();
+        let count = orphan_pages.len();
+
+        // Look for duplicate entries
+        let mut orphan_page_ids = HashSet::new();
+
+        for orphan_page in orphan_pages.iter() {
+            assert!(
+                orphan_page_ids.insert(orphan_page.page_id()),
+                "page {} is already in the orphan page list",
+                orphan_page.page_id()
+            );
+        }
+
+        assert!(
+            orphan_page_ids.contains(&target_page_id),
+            "target page {target_page_id} is not in the orphan page list"
+        );
+        assert!(
+            orphan_page_ids.contains(&parent_page_id),
+            "parent page {parent_page_id} is not in the orphan page list"
+        );
+        assert_eq!(count, 4, "Expected 4 orphan pages after the delete operation");
     }
 }


### PR DESCRIPTION
Fixes the page orphaning logic to explicitly orphan pages as they are unreferenced, instead of doing so whenever a `PointerChange::Delete` is encountered.

Adds a test which previously reproduced the double-orphan bug by simultaneously deleting an Account at the root of one page, as well as its parent Branch at the root of another page.