### PR TITLE
Improve the error message generated by `assert_metrics`

### DIFF
--- a/src/storage/test_utils.rs
+++ b/src/storage/test_utils.rs
@@ -34,24 +34,26 @@ pub(crate) fn assert_metrics(
     pages_reallocated: u32,
     pages_split: u32,
 ) {
-    assert_eq!(
-        context.transaction_metrics.get_pages_read(),
-        pages_read,
-        "unexpected number of pages read"
-    );
-    assert_eq!(
-        context.transaction_metrics.get_pages_allocated(),
-        pages_allocated,
-        "unexpected number of pages allocated"
-    );
-    assert_eq!(
-        context.transaction_metrics.get_pages_reallocated(),
-        pages_reallocated,
-        "unexpected number of pages reallocated"
-    );
-    assert_eq!(
-        context.transaction_metrics.get_pages_split(),
-        pages_split,
-        "unexpected number of pages split"
+    /// Struct used to make error messages easier to read
+    #[derive(PartialEq, Eq, Debug)]
+    struct Metrics {
+        pages_read: u32,
+        pages_allocated: u32,
+        pages_reallocated: u32,
+        pages_split: u32,
+    }
+
+    let expected = Metrics { pages_read, pages_allocated, pages_reallocated, pages_split };
+
+    let actual = Metrics {
+        pages_read: context.transaction_metrics.get_pages_read(),
+        pages_allocated: context.transaction_metrics.get_pages_allocated(),
+        pages_reallocated: context.transaction_metrics.get_pages_reallocated(),
+        pages_split: context.transaction_metrics.get_pages_split(),
+    };
+
+    assert!(
+        expected == actual,
+        "transaction metrics don't match:\n expected: {expected:?}\n   actual: {actual:?}"
     );
 }


### PR DESCRIPTION
Now when `assert_metric` fails you get a more complete error message that shows all the differences, in a more readable format.

Old error message:

```
assertion `left == right` failed: unexpected number of pages allocated
  left: 1
 right: 2
```

New error message:

```
transaction metrics don't match:
 expected: Metrics { pages_read: 1, pages_allocated: 2, pages_reallocated: 3, pages_split: 4 }
   actual: Metrics { pages_read: 1, pages_allocated: 1, pages_reallocated: 0, pages_split: 0 }
```

The metrics are repeated twice; that's because I find expected/actual easier to understand than left/right.